### PR TITLE
feat: make preferences and settings editable in users/me patch route

### DIFF
--- a/src/users/controllers/user-profiles.controller.spec.ts
+++ b/src/users/controllers/user-profiles.controller.spec.ts
@@ -160,6 +160,21 @@ describe('UserProfilesController', () => {
         zip: '10115',
       });
     });
+
+    it('should update settings', async () => {
+      const updateDto = { settings: { notifications: true, theme: 'dark' } };
+
+      service.getProfileByUserId.mockResolvedValue(mockUserProfile);
+      service.updateProfile.mockResolvedValue({
+        ...mockUserProfile,
+        settings: updateDto.settings,
+      });
+
+      const result = await controller.updateProfile('user-1', updateDto as any);
+
+      expect(result.settings).toEqual(updateDto.settings);
+      expect(service.updateProfile).toHaveBeenCalledWith('kc-1', updateDto);
+    });
   });
 
   describe('deleteMe', () => {

--- a/src/users/controllers/user-profiles.controller.spec.ts
+++ b/src/users/controllers/user-profiles.controller.spec.ts
@@ -175,6 +175,21 @@ describe('UserProfilesController', () => {
       expect(result.settings).toEqual(updateDto.settings);
       expect(service.updateProfile).toHaveBeenCalledWith('kc-1', updateDto);
     });
+
+    it('should update preferences', async () => {
+      const updateDto = { preferences: { newsletter: false, timezone: 'Europe/Berlin' } };
+
+      service.getProfileByUserId.mockResolvedValue(mockUserProfile);
+      service.updateProfile.mockResolvedValue({
+        ...mockUserProfile,
+        preferences: updateDto.preferences,
+      });
+
+      const result = await controller.updateProfile('user-1', updateDto as any);
+
+      expect(result.preferences).toEqual(updateDto.preferences);
+      expect(service.updateProfile).toHaveBeenCalledWith('kc-1', updateDto);
+    });
   });
 
   describe('deleteMe', () => {

--- a/src/users/dto/profile-update.dto.ts
+++ b/src/users/dto/profile-update.dto.ts
@@ -109,4 +109,13 @@ export class ProfileUpdateDto {
   @IsOptional()
   @IsObject()
   preferences?: Record<string, any>;
+
+  @ApiProperty({
+    description: 'User settings (JSON) - app/notification settings, etc.',
+    required: false,
+    example: { notifications: true, theme: 'dark' },
+  })
+  @IsOptional()
+  @IsObject()
+  settings?: Record<string, any>;
 }

--- a/src/users/services/user-profiles.service.ts
+++ b/src/users/services/user-profiles.service.ts
@@ -93,8 +93,6 @@ export class UserProfilesService {
       'username',
       'createdAt',
       'updatedAt',
-      'preferences',
-      'settings',
       'shoppingList',
       'pantry',
     ];
@@ -132,6 +130,8 @@ export class UserProfilesService {
       'activityLevel',
       'healthGoals',
       'nutritionTargets',
+      'settings',
+      'preferences',
     ];
 
     for (const f of extendedFields) {


### PR DESCRIPTION
# Pull Request

## Description

make preferences and settings editable in users/me patch route

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Security fix

## Type of Changes

- [ ] Database changes
- [ ] Schema changes (migration included)
- [ ] Seed data changes
- [x] API changes
- [ ] New Entity

## Changes Made

- Added preferences and settings to the editable fields in the users/me route.

---

## 🐳 Docker Image Preview

**Available tags:**
- `ghcr.io/reedu-reengineering-education/foodmission-data-framework:pr-197`
- `ghcr.io/reedu-reengineering-education/foodmission-data-framework:sha-34a8d60`

**Pull and test:**
```bash
docker pull ghcr.io/reedu-reengineering-education/foodmission-data-framework:pr-197
docker run -p 3000:3000 ghcr.io/reedu-reengineering-education/foodmission-data-framework:pr-197
```

**Multi-arch support:** ✅ AMD64 & ARM64
