### PR TITLE
Recipe Analytics Public Endpoints + Seed

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       POSTGRES_PASSWORD: password
       POSTGRES_DB: foodmission_db
     ports:
-      - '5434:5432'
+      - '5432:5432'
     volumes:
       - postgres_data:/var/lib/postgresql/data
       - ./scripts/init-test-db.sql:/docker-entrypoint-initdb.d/init-test-db.sql
@@ -18,7 +18,7 @@ services:
       retries: 5
 
   redis:
-    image: redis:7.2-alpine
+    image: valkey/valkey:9.1.0
     container_name: foodmission-redis
     ports:
       - '6379:6379'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       POSTGRES_PASSWORD: password
       POSTGRES_DB: foodmission_db
     ports:
-      - '5432:5432'
+      - '5434:5432'
     volumes:
       - postgres_data:/var/lib/postgresql/data
       - ./scripts/init-test-db.sql:/docker-entrypoint-initdb.d/init-test-db.sql
@@ -18,7 +18,7 @@ services:
       retries: 5
 
   redis:
-    image: valkey/valkey:9.1.0
+    image: redis:7.2-alpine
     container_name: foodmission-redis
     ports:
       - '6379:6379'

--- a/docs/Data anonymization/analytics_instructions.md
+++ b/docs/Data anonymization/analytics_instructions.md
@@ -147,3 +147,44 @@ Shopping List analytics intentionally does not expose nutrition or per-100g nutr
 ```
 npm run db:clean:shopping-lists
 ```
+
+---
+
+## Recipe Analytics
+
+1. Run normal seed for DB (if not already done)
+
+```
+npm run db:seed
+```
+
+2. Run recipe logs seed (creates 135 recipes across ~95 days + linked cooking usage meals)
+
+```
+npm run db:seed:recipes-logs
+```
+
+3. Public endpoints are available directly (no batch publish step required):
+
+```
+{{baseUrl}}/api/v1/analytics/recipes/public/summary
+{{baseUrl}}/api/v1/analytics/recipes/public/diet-trend
+{{baseUrl}}/api/v1/analytics/recipes/public/diet-distribution
+{{baseUrl}}/api/v1/analytics/recipes/public/nutrition
+{{baseUrl}}/api/v1/analytics/recipes/public/sustainability
+{{baseUrl}}/api/v1/analytics/recipes/public/top-ingredients
+{{baseUrl}}/api/v1/analytics/recipes/public/ingredient-categories
+{{baseUrl}}/api/v1/analytics/recipes/public/diversity
+{{baseUrl}}/api/v1/analytics/recipes/public/cuisine-trends
+{{baseUrl}}/api/v1/analytics/recipes/public/cooking-patterns
+{{baseUrl}}/api/v1/analytics/recipes/public/difficulty
+{{baseUrl}}/api/v1/analytics/recipes/public/usage
+```
+
+4. Supported query params (all recipe public routes):
+
+```
+?from=2026-03-01&to=2026-06-01
+```
+
+`from` and `to` are optional ISO date values.

--- a/package-lock.json
+++ b/package-lock.json
@@ -48,7 +48,7 @@
         "joi": "^18.2.1",
         "keycloak-connect": "^26.1.1",
         "keyv": "^5.5.1",
-        "nest-keycloak-connect": "^2.0.0-alpha.3",
+        "nest-keycloak-connect": "^2.0.0-alpha.2",
         "prisma": "^6.19.3",
         "prom-client": "^15.1.3",
         "reflect-metadata": "^0.2.2",
@@ -10366,9 +10366,7 @@
       "license": "MIT"
     },
     "node_modules/nest-keycloak-connect": {
-      "version": "2.0.0-alpha.3",
-      "resolved": "https://registry.npmjs.org/nest-keycloak-connect/-/nest-keycloak-connect-2.0.0-alpha.3.tgz",
-      "integrity": "sha512-J+106q+nlLdFyUm7kCTNI3n++PZnrAObi3ufh/hMcvOw8nnRQ/6QM2A7tu6ou3oVKppupMKUbIVXvXKcRYsgMQ==",
+      "version": "2.0.0-alpha.2",
       "funding": [
         {
           "type": "individual",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "db:seed:foods": "ts-node scripts/seeds/seed-food-products-only.ts",
     "db:seed:meal-logs": "ts-node scripts/seeds/dev/seed-meal-logs.ts",
     "db:seed:shopping-lists": "ts-node scripts/seeds/dev/seed-shopping-lists.ts",
+    "db:seed:recipes-logs": "ts-node scripts/seeds/dev/seed-recipe-logs.ts",
     "db:clean:meal-logs": "ts-node scripts/dev/clean-meal-logs.ts",
     "db:clean:shopping-lists": "ts-node scripts/dev/clean-shopping-lists.ts",
     "db:clean:analytics": "ts-node scripts/dev/clean-analytics.ts",

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "joi": "^18.2.1",
     "keycloak-connect": "^26.1.1",
     "keyv": "^5.5.1",
-    "nest-keycloak-connect": "^2.0.0-alpha.3",
+    "nest-keycloak-connect": "^2.0.0-alpha.2",
     "prisma": "^6.19.3",
     "prom-client": "^15.1.3",
     "reflect-metadata": "^0.2.2",

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -43,6 +43,7 @@ Interactive Swagger UI: run the API and open `/api/docs` (see root `README.md` Â
 The `scripts/dev/` folder contains meal-log analytics development utilities:
 
 - `seed-meal-logs.ts` - Generate synthetic meal-log data for analytics testing
+- `seed-recipe-logs.ts` - Generate recipe analytics seed data (recipes + ingredient + usage patterns)
 - `clean-meal-logs.ts` - Remove generated meal-log records
 - `clean-analytics.ts` - Remove generated analytics batch/output records
 
@@ -64,6 +65,7 @@ npm run db:seed:foods
 
 # Meal-log analytics dev scripts
 npm run db:seed:meal-logs
+npm run db:seed:recipes-logs
 npm run db:clean:meal-logs
 npm run db:clean:analytics
 

--- a/scripts/seeds/dev/seed-recipe-logs.ts
+++ b/scripts/seeds/dev/seed-recipe-logs.ts
@@ -1,0 +1,288 @@
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+const RUN_PREFIX = '[RA-SEED]';
+const RECIPE_COUNT = 135;
+const DAYS_SPAN = 95;
+
+const DIET_LABELS = [
+  'vegan',
+  'vegetarian',
+  'pescatarian',
+  'meat-based',
+  'gluten-free',
+  'lactose-free',
+  'low-carb',
+  'high-protein',
+  'keto',
+] as const;
+
+const CUISINES = [
+  'Italian',
+  'Mexican',
+  'Japanese',
+  'Thai',
+  'Indian',
+  'Mediterranean',
+  'French',
+  'Middle Eastern',
+  'Nordic',
+  'American',
+] as const;
+
+const DIFFICULTIES = ['easy', 'medium', 'hard'] as const;
+
+const INGREDIENT_POOL = [
+  'Tomato',
+  'Onion',
+  'Garlic',
+  'Olive Oil',
+  'Bell Pepper',
+  'Carrot',
+  'Broccoli',
+  'Spinach',
+  'Chickpeas',
+  'Lentils',
+  'Tofu',
+  'Tempeh',
+  'Chicken Breast',
+  'Beef',
+  'Salmon',
+  'Tuna',
+  'Egg',
+  'Yogurt',
+  'Cheese',
+  'Milk',
+  'Rice',
+  'Quinoa',
+  'Pasta',
+  'Potato',
+  'Sweet Potato',
+  'Avocado',
+  'Lemon',
+  'Apple',
+  'Banana',
+  'Mushroom',
+  'Basil',
+  'Parsley',
+  'Soy Sauce',
+  'Coconut Milk',
+  'Ginger',
+  'Black Pepper',
+  'Sea Salt',
+  'Oats',
+  'Almonds',
+  'Peanut Butter',
+  'Kidney Beans',
+  'Corn',
+  'Cucumber',
+  'Zucchini',
+  'Cauliflower',
+  'Shrimp',
+] as const;
+
+function createRng(seed: number) {
+  let state = seed >>> 0;
+  return () => {
+    state = (1664525 * state + 1013904223) >>> 0;
+    return state / 0x100000000;
+  };
+}
+
+function pickOne<T>(items: readonly T[], rng: () => number): T {
+  return items[Math.floor(rng() * items.length)];
+}
+
+function pickUnique<T>(items: readonly T[], count: number, rng: () => number): T[] {
+  const copy = [...items];
+  const selected: T[] = [];
+
+  while (copy.length > 0 && selected.length < count) {
+    const idx = Math.floor(rng() * copy.length);
+    selected.push(copy[idx]);
+    copy.splice(idx, 1);
+  }
+
+  return selected;
+}
+
+function normalizeTitleSeed(value: string) {
+  return value.replace(/[^a-z0-9]+/gi, ' ').trim();
+}
+
+async function seedRecipeLogs() {
+  const rng = createRng(20260618);
+
+  const users = await prisma.user.findMany({
+    select: { id: true },
+    orderBy: { createdAt: 'asc' },
+    take: 30,
+  });
+
+  if (users.length === 0) {
+    throw new Error('No users found. Run npm run db:seed first.');
+  }
+
+  console.log(`Found ${users.length} users.`);
+
+  const existingSeededRecipes = await prisma.recipe.findMany({
+    where: { externalId: { startsWith: 'ra-seed-' } },
+    select: { id: true },
+  });
+
+  await prisma.meal.deleteMany({
+    where: {
+      name: { startsWith: RUN_PREFIX },
+    },
+  });
+
+  if (existingSeededRecipes.length > 0) {
+    await prisma.recipe.deleteMany({
+      where: {
+        externalId: { startsWith: 'ra-seed-' },
+      },
+    });
+  }
+
+  const now = new Date();
+  let totalIngredients = 0;
+  let totalMeals = 0;
+
+  for (let i = 0; i < RECIPE_COUNT; i++) {
+    const user = users[i % users.length];
+    const cuisine = pickOne(CUISINES, rng);
+    const difficulty = pickOne(DIFFICULTIES, rng);
+
+    const daysAgo = Math.floor((i / RECIPE_COUNT) * DAYS_SPAN);
+    const createdAt = new Date(now);
+    createdAt.setUTCDate(createdAt.getUTCDate() - daysAgo);
+    createdAt.setUTCHours(8 + (i % 12), Math.floor(rng() * 60), 0, 0);
+
+    const titleSeed = normalizeTitleSeed(
+      `${cuisine} ${difficulty} recipe ${i + 1}`,
+    );
+    const title = `${titleSeed} ${RUN_PREFIX}`;
+
+    const prepTime = 8 + Math.floor(rng() * 45);
+    const cookTime = 10 + Math.floor(rng() * 70);
+
+    const rating = Math.round((2.5 + rng() * 2.5) * 100) / 100;
+    const ratingCount = 5 + Math.floor(rng() * 320);
+
+    const dietCount = 1 + Math.floor(rng() * 3);
+    const diets = pickUnique(DIET_LABELS, dietCount, rng);
+
+    if (i % 9 === 0 && !diets.includes('keto')) diets.push('keto');
+    if (i % 11 === 0 && !diets.includes('vegan')) diets.push('vegan');
+    if (i % 7 === 0 && !diets.includes('meat-based')) diets.push('meat-based');
+
+    const ingredientCount = 6 + Math.floor(rng() * 6);
+    const ingredients = pickUnique(INGREDIENT_POOL, ingredientCount, rng).map(
+      (name, idx) => ({
+        name,
+        order: idx,
+        measure: `${1 + Math.floor(rng() * 3)} portion`,
+      }),
+    );
+
+    totalIngredients += ingredients.length;
+
+    const nutrition = {
+      calories: Math.round(280 + rng() * 560),
+      protein: Math.round((12 + rng() * 42) * 10) / 10,
+      carbs: Math.round((15 + rng() * 85) * 10) / 10,
+      fat: Math.round((8 + rng() * 45) * 10) / 10,
+      fiber: Math.round((3 + rng() * 16) * 10) / 10,
+      sugar: Math.round((2 + rng() * 22) * 10) / 10,
+      salt: Math.round((0.2 + rng() * 2.6) * 100) / 100,
+      ecoScore: Math.round(35 + rng() * 60),
+      sustainabilityScore: Math.round(40 + rng() * 58),
+      co2Footprint: Math.round((0.8 + rng() * 7.4) * 100) / 100,
+      waterFootprint: Math.round(120 + rng() * 1600),
+      seasonalShare: Math.round((0.25 + rng() * 0.7) * 100) / 100,
+      localShare: Math.round((0.2 + rng() * 0.75) * 100) / 100,
+    };
+
+    const recipe = await prisma.recipe.create({
+      data: {
+        userId: user.id,
+        title,
+        description: `Synthetic recipe analytics seed #${i + 1}`,
+        instructions: 'Mix, cook, and serve.',
+        prepTime,
+        cookTime,
+        servings: 2 + Math.floor(rng() * 5),
+        difficulty,
+        tags: ['analytics-seed', cuisine.toLowerCase().replace(/\s+/g, '-')],
+        nutritionalInfo: nutrition,
+        sustainabilityScore: nutrition.sustainabilityScore,
+        price: Math.round((4 + rng() * 22) * 100) / 100,
+        allergens: [],
+        rating,
+        ratingCount,
+        externalId: `ra-seed-${String(i + 1).padStart(4, '0')}`,
+        imageUrl: null,
+        videoUrl: null,
+        cuisineType: cuisine,
+        category: 'Main',
+        isPublic: i % 5 !== 0,
+        dietaryLabels: diets,
+        createdAt,
+        updatedAt: createdAt,
+        ingredients: {
+          create: ingredients,
+        },
+      },
+      select: { id: true },
+    });
+
+    const cookEvents = 1 + Math.floor(rng() * 7);
+    totalMeals += cookEvents;
+
+    for (let m = 0; m < cookEvents; m++) {
+      const mealUser = users[(i + m) % users.length];
+      const mealDate = new Date(createdAt);
+      mealDate.setUTCDate(mealDate.getUTCDate() + (m % 21));
+
+      await prisma.meal.create({
+        data: {
+          name: `${RUN_PREFIX} Meal ${i + 1}-${m + 1}`,
+          userId: mealUser.id,
+          recipeId: recipe.id,
+          createdAt: mealDate,
+          updatedAt: mealDate,
+        },
+      });
+    }
+
+    if ((i + 1) % 25 === 0) {
+      console.log(`Seed progress: ${i + 1}/${RECIPE_COUNT} recipes`);
+    }
+  }
+
+  const minDate = new Date(now);
+  minDate.setUTCDate(minDate.getUTCDate() - DAYS_SPAN);
+
+  console.log('');
+  console.log('Recipe logs seed completed.');
+  console.log(`Recipes created: ${RECIPE_COUNT}`);
+  console.log(`Meals created: ${totalMeals}`);
+  console.log(`Recipe ingredients created: ${totalIngredients}`);
+  console.log(`Active recipes (isPublic=true): ${Math.ceil(RECIPE_COUNT * 0.8)}`);
+  console.log(`Archived recipes (isPublic=false): ${Math.floor(RECIPE_COUNT * 0.2)}`);
+  console.log(
+    `Suggested range: from=${minDate.toISOString().slice(0, 10)} to=${now
+      .toISOString()
+      .slice(0, 10)}`,
+  );
+}
+
+seedRecipeLogs()
+  .catch((error) => {
+    console.error('Recipe analytics seed failed:', error);
+    process.exit(1);
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });

--- a/src/analytics/analytics.module.ts
+++ b/src/analytics/analytics.module.ts
@@ -9,6 +9,9 @@ import { ShoppingListAnalyticsController } from './shopping-list/controllers/sho
 import { ShoppingListAnalyticsService } from './shopping-list/services/shopping-list-analytics.service';
 import { ShoppingListAnalyticsAggregator } from './shopping-list/services/shopping-list-analytics-aggregator.service';
 import { ShoppingListAnalyticsRepository } from './shopping-list/repositories/shopping-list-analytics.repository';
+import { RecipeAnalyticsController } from './recipes/controllers/recipe-analytics.controller';
+import { RecipeAnalyticsService } from './recipes/services/recipe-analytics.service';
+import { RecipeAnalyticsRepository } from './recipes/repositories/recipe-analytics.repository';
 import { UsersRepository } from '../users/repositories/users.repository';
 import { AnalyticsBatchCoordinator } from './analytics-batch-coordinator.service';
 
@@ -18,6 +21,7 @@ import { AnalyticsBatchCoordinator } from './analytics-batch-coordinator.service
     AnalyticsController,
     MealLogAnalyticsController,
     ShoppingListAnalyticsController,
+    RecipeAnalyticsController,
   ],
   providers: [
     MealLogAnalyticsService,
@@ -26,9 +30,15 @@ import { AnalyticsBatchCoordinator } from './analytics-batch-coordinator.service
     ShoppingListAnalyticsService,
     ShoppingListAnalyticsAggregator,
     ShoppingListAnalyticsRepository,
+    RecipeAnalyticsService,
+    RecipeAnalyticsRepository,
     UsersRepository,
     AnalyticsBatchCoordinator,
   ],
-  exports: [MealLogAnalyticsService, ShoppingListAnalyticsService],
+  exports: [
+    MealLogAnalyticsService,
+    ShoppingListAnalyticsService,
+    RecipeAnalyticsService,
+  ],
 })
 export class AnalyticsModule {}

--- a/src/analytics/recipes/controllers/recipe-analytics.controller.ts
+++ b/src/analytics/recipes/controllers/recipe-analytics.controller.ts
@@ -1,0 +1,120 @@
+import { Controller, Get, Query } from '@nestjs/common';
+import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { Public } from 'nest-keycloak-connect';
+import { DateRangeQuery } from '../../common/decorators/date-range-query.decorator';
+import { RecipeAnalyticsQueryDto } from '../dto/recipe-analytics-query.dto';
+import { RecipeAnalyticsService } from '../services/recipe-analytics.service';
+
+@ApiTags('analytics-recipes')
+@Controller('analytics/recipes')
+export class RecipeAnalyticsController {
+  constructor(private readonly recipeAnalyticsService: RecipeAnalyticsService) {}
+
+  @Public()
+  @Get('public/summary')
+  @ApiOperation({ summary: 'Recipe analytics summary KPIs' })
+  @DateRangeQuery()
+  @ApiResponse({ status: 200, description: 'Recipe analytics summary' })
+  getPublicSummary(@Query() query: RecipeAnalyticsQueryDto) {
+    return this.recipeAnalyticsService.getSummary(query);
+  }
+
+  @Public()
+  @Get('public/diet-trend')
+  @ApiOperation({ summary: 'Daily trend of recipe diet labels' })
+  @DateRangeQuery()
+  @ApiResponse({ status: 200, description: 'Diet trend time series' })
+  getPublicDietTrend(@Query() query: RecipeAnalyticsQueryDto) {
+    return this.recipeAnalyticsService.getDietTrend(query);
+  }
+
+  @Public()
+  @Get('public/diet-distribution')
+  @ApiOperation({ summary: 'Diet label distribution across recipes' })
+  @DateRangeQuery()
+  @ApiResponse({ status: 200, description: 'Diet distribution' })
+  getPublicDietDistribution(@Query() query: RecipeAnalyticsQueryDto) {
+    return this.recipeAnalyticsService.getDietDistribution(query);
+  }
+
+  @Public()
+  @Get('public/nutrition')
+  @ApiOperation({ summary: 'Recipe nutrition analytics over time' })
+  @DateRangeQuery()
+  @ApiResponse({ status: 200, description: 'Nutrition trend rows' })
+  getPublicNutrition(@Query() query: RecipeAnalyticsQueryDto) {
+    return this.recipeAnalyticsService.getNutrition(query);
+  }
+
+  @Public()
+  @Get('public/sustainability')
+  @ApiOperation({ summary: 'Recipe sustainability analytics over time' })
+  @DateRangeQuery()
+  @ApiResponse({ status: 200, description: 'Sustainability trend rows' })
+  getPublicSustainability(@Query() query: RecipeAnalyticsQueryDto) {
+    return this.recipeAnalyticsService.getSustainability(query);
+  }
+
+  @Public()
+  @Get('public/top-ingredients')
+  @ApiOperation({ summary: 'Most used ingredients in recipes' })
+  @DateRangeQuery()
+  @ApiResponse({ status: 200, description: 'Top ingredients list' })
+  getPublicTopIngredients(@Query() query: RecipeAnalyticsQueryDto) {
+    return this.recipeAnalyticsService.getTopIngredients(query);
+  }
+
+  @Public()
+  @Get('public/ingredient-categories')
+  @ApiOperation({ summary: 'Ingredient category usage in recipes' })
+  @DateRangeQuery()
+  @ApiResponse({ status: 200, description: 'Ingredient category distribution' })
+  getPublicIngredientCategories(@Query() query: RecipeAnalyticsQueryDto) {
+    return this.recipeAnalyticsService.getIngredientCategories(query);
+  }
+
+  @Public()
+  @Get('public/diversity')
+  @ApiOperation({ summary: 'Recipe diversity metrics' })
+  @DateRangeQuery()
+  @ApiResponse({ status: 200, description: 'Diversity metrics' })
+  getPublicDiversity(@Query() query: RecipeAnalyticsQueryDto) {
+    return this.recipeAnalyticsService.getDiversity(query);
+  }
+
+  @Public()
+  @Get('public/cuisine-trends')
+  @ApiOperation({ summary: 'Cuisine trend analytics' })
+  @DateRangeQuery()
+  @ApiResponse({ status: 200, description: 'Cuisine trend rows' })
+  getPublicCuisineTrends(@Query() query: RecipeAnalyticsQueryDto) {
+    return this.recipeAnalyticsService.getCuisineTrends(query);
+  }
+
+  @Public()
+  @Get('public/cooking-patterns')
+  @ApiOperation({ summary: 'Cooking time pattern analytics' })
+  @DateRangeQuery()
+  @ApiResponse({ status: 200, description: 'Cooking pattern metrics' })
+  getPublicCookingPatterns(@Query() query: RecipeAnalyticsQueryDto) {
+    return this.recipeAnalyticsService.getCookingPatterns(query);
+  }
+
+  @Public()
+  @Get('public/difficulty')
+  @ApiOperation({ summary: 'Recipe difficulty distribution' })
+  @DateRangeQuery()
+  @ApiResponse({ status: 200, description: 'Difficulty distribution rows' })
+  getPublicDifficulty(@Query() query: RecipeAnalyticsQueryDto) {
+    return this.recipeAnalyticsService.getDifficulty(query);
+  }
+
+  @Public()
+  @Get('public/usage')
+  @ApiOperation({ summary: 'Recipe usage analytics based on cooking events' })
+  @DateRangeQuery()
+  @ApiResponse({ status: 200, description: 'Usage metrics' })
+  getPublicUsage(@Query() query: RecipeAnalyticsQueryDto) {
+    return this.recipeAnalyticsService.getUsage(query);
+  }
+}

--- a/src/analytics/recipes/dto/recipe-analytics-query.dto.ts
+++ b/src/analytics/recipes/dto/recipe-analytics-query.dto.ts
@@ -1,0 +1,11 @@
+import { IsDateString, IsOptional } from 'class-validator';
+
+export class RecipeAnalyticsQueryDto {
+  @IsOptional()
+  @IsDateString()
+  from?: string;
+
+  @IsOptional()
+  @IsDateString()
+  to?: string;
+}

--- a/src/analytics/recipes/repositories/recipe-analytics.repository.ts
+++ b/src/analytics/recipes/repositories/recipe-analytics.repository.ts
@@ -1,0 +1,63 @@
+import { Injectable } from '@nestjs/common';
+import { Prisma } from '@prisma/client';
+import { PrismaService } from '../../../database/prisma.service';
+
+@Injectable()
+export class RecipeAnalyticsRepository {
+  constructor(private readonly prisma: PrismaService) {}
+
+  findRecipes(from?: Date, to?: Date) {
+    return this.prisma.recipe.findMany({
+      where: {
+        createdAt: this.buildDateFilter(from, to),
+      },
+      select: {
+        id: true,
+        title: true,
+        createdAt: true,
+        prepTime: true,
+        cookTime: true,
+        difficulty: true,
+        nutritionalInfo: true,
+        sustainabilityScore: true,
+        rating: true,
+        ratingCount: true,
+        cuisineType: true,
+        dietaryLabels: true,
+        isPublic: true,
+        ingredients: {
+          select: {
+            name: true,
+          },
+        },
+        meals: {
+          where: {
+            createdAt: this.buildDateFilter(from, to),
+          },
+          select: {
+            id: true,
+            userId: true,
+            createdAt: true,
+          },
+        },
+      },
+      orderBy: {
+        createdAt: 'asc',
+      },
+    });
+  }
+
+  private buildDateFilter(
+    from?: Date,
+    to?: Date,
+  ): Prisma.DateTimeFilter | undefined {
+    if (!from && !to) {
+      return undefined;
+    }
+
+    return {
+      ...(from ? { gte: from } : {}),
+      ...(to ? { lte: to } : {}),
+    };
+  }
+}

--- a/src/analytics/recipes/services/recipe-analytics.service.ts
+++ b/src/analytics/recipes/services/recipe-analytics.service.ts
@@ -1,0 +1,745 @@
+import { BadRequestException, Injectable } from '@nestjs/common';
+import { Prisma } from '@prisma/client';
+import { RecipeAnalyticsQueryDto } from '../dto/recipe-analytics-query.dto';
+import { RecipeAnalyticsRepository } from '../repositories/recipe-analytics.repository';
+
+const DIET_LABELS = [
+  'vegan',
+  'vegetarian',
+  'pescatarian',
+  'meat-based',
+  'gluten-free',
+  'lactose-free',
+  'low-carb',
+  'high-protein',
+  'keto',
+] as const;
+
+type DietLabel = (typeof DIET_LABELS)[number];
+
+type RecipeAnalyticsRow = Awaited<
+  ReturnType<RecipeAnalyticsRepository['findRecipes']>
+>[number];
+
+interface RecipeScore {
+  recipeId: string;
+  title: string;
+  cookCount: number;
+  viewCount: number;
+  savedCount: number;
+  trendScore: number;
+  rating: number;
+  ratingCount: number;
+}
+
+@Injectable()
+export class RecipeAnalyticsService {
+  constructor(private readonly repository: RecipeAnalyticsRepository) {}
+
+  async getSummary(query: RecipeAnalyticsQueryDto) {
+    const { from, to, fromRaw, toRaw } = this.parseRange(query);
+    const recipes = await this.repository.findRecipes(from, to);
+    const scored = recipes.map((recipe) => this.scoreRecipe(recipe));
+
+    const now = new Date();
+    const sevenDaysAgo = new Date(now);
+    sevenDaysAgo.setUTCDate(sevenDaysAgo.getUTCDate() - 7);
+    const thirtyDaysAgo = new Date(now);
+    thirtyDaysAgo.setUTCDate(thirtyDaysAgo.getUTCDate() - 30);
+
+    const totalRecipes = recipes.length;
+    const activeRecipes = recipes.filter((r) => r.isPublic).length;
+    const archivedRecipes = totalRecipes - activeRecipes;
+    const avgRating = this.round2(
+      this.avg(recipes.map((r) => r.rating).filter((v) => v > 0)),
+    );
+
+    return {
+      period: {
+        from: fromRaw,
+        to: toRaw,
+      },
+      totalRecipes,
+      newRecipes7d: recipes.filter((r) => r.createdAt >= sevenDaysAgo).length,
+      newRecipes30d: recipes.filter((r) => r.createdAt >= thirtyDaysAgo).length,
+      activeRecipes,
+      archivedRecipes,
+      avgRating,
+      mostViewedRecipes: scored
+        .slice()
+        .sort((a, b) => b.viewCount - a.viewCount)
+        .slice(0, 10)
+        .map((r) => ({ title: r.title, viewCount: r.viewCount })),
+      mostCookedRecipes: scored
+        .slice()
+        .sort((a, b) => b.cookCount - a.cookCount)
+        .slice(0, 10)
+        .map((r) => ({ title: r.title, cookCount: r.cookCount })),
+      mostSavedRecipes: scored
+        .slice()
+        .sort((a, b) => b.savedCount - a.savedCount)
+        .slice(0, 10)
+        .map((r) => ({ title: r.title, savedCount: r.savedCount })),
+      highestRatedRecipes: scored
+        .filter((r) => r.ratingCount > 0)
+        .sort((a, b) => b.rating - a.rating || b.ratingCount - a.ratingCount)
+        .slice(0, 10)
+        .map((r) => ({
+          title: r.title,
+          rating: this.round2(r.rating),
+          ratingCount: r.ratingCount,
+        })),
+      trendingRecipes: scored
+        .slice()
+        .sort((a, b) => b.trendScore - a.trendScore)
+        .slice(0, 10)
+        .map((r) => ({ title: r.title, trendScore: this.round2(r.trendScore) })),
+    };
+  }
+
+  async getDietTrend(query: RecipeAnalyticsQueryDto) {
+    const { from, to } = this.parseRange(query);
+    const recipes = await this.repository.findRecipes(from, to);
+    const byDate = this.groupBy(
+      recipes,
+      (r) => r.createdAt.toISOString().slice(0, 10),
+    );
+
+    return [...byDate.entries()]
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([date, rows]) => {
+        const total = rows.length;
+
+        return {
+          date,
+          recipeCount: total,
+          veganPct: this.pct(rows, 'vegan'),
+          vegetarianPct: this.pct(rows, 'vegetarian'),
+          pescatarianPct: this.pct(rows, 'pescatarian'),
+          meatBasedPct: this.pct(rows, 'meat-based'),
+          glutenFreePct: this.pct(rows, 'gluten-free'),
+          lactoseFreePct: this.pct(rows, 'lactose-free'),
+          lowCarbPct: this.pct(rows, 'low-carb'),
+          highProteinPct: this.pct(rows, 'high-protein'),
+          ketoPct: this.pct(rows, 'keto'),
+        };
+      });
+  }
+
+  async getDietDistribution(query: RecipeAnalyticsQueryDto) {
+    const { from, to } = this.parseRange(query);
+    const recipes = await this.repository.findRecipes(from, to);
+
+    return {
+      totalRecipes: recipes.length,
+      labels: DIET_LABELS.map((label) => {
+        const count = recipes.filter((r) => r.dietaryLabels.includes(label)).length;
+        return {
+          label,
+          count,
+          pct:
+            recipes.length === 0
+              ? 0
+              : this.round2((count / recipes.length) * 100),
+        };
+      }),
+    };
+  }
+
+  async getNutrition(query: RecipeAnalyticsQueryDto) {
+    const { from, to } = this.parseRange(query);
+    const recipes = await this.repository.findRecipes(from, to);
+    const byDate = this.groupBy(
+      recipes,
+      (r) => r.createdAt.toISOString().slice(0, 10),
+    );
+
+    return [...byDate.entries()]
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([date, rows]) => {
+        const nutrition = rows.map((r) => this.getNutritionInfo(r.nutritionalInfo));
+        return {
+          date,
+          recipeCount: rows.length,
+          avgCalories: this.round2(this.avg(nutrition.map((n) => n.calories))),
+          avgProtein: this.round2(this.avg(nutrition.map((n) => n.protein))),
+          avgCarbs: this.round2(this.avg(nutrition.map((n) => n.carbs))),
+          avgFat: this.round2(this.avg(nutrition.map((n) => n.fat))),
+          avgFiber: this.round2(this.avg(nutrition.map((n) => n.fiber))),
+          avgSugar: this.round2(this.avg(nutrition.map((n) => n.sugar))),
+          avgSalt: this.round2(this.avg(nutrition.map((n) => n.salt))),
+        };
+      });
+  }
+
+  async getSustainability(query: RecipeAnalyticsQueryDto) {
+    const { from, to } = this.parseRange(query);
+    const recipes = await this.repository.findRecipes(from, to);
+    const byDate = this.groupBy(
+      recipes,
+      (r) => r.createdAt.toISOString().slice(0, 10),
+    );
+
+    return [...byDate.entries()]
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([date, rows]) => {
+        const sustainability = rows.map((r) =>
+          this.getSustainabilityInfo(r.nutritionalInfo, r.sustainabilityScore),
+        );
+
+        return {
+          date,
+          recipeCount: rows.length,
+          avgEcoScore: this.round2(this.avg(sustainability.map((s) => s.ecoScore))),
+          avgSustainabilityScore: this.round2(
+            this.avg(sustainability.map((s) => s.sustainabilityScore)),
+          ),
+          avgCo2Footprint: this.round2(
+            this.avg(sustainability.map((s) => s.co2Footprint)),
+          ),
+          avgWaterFootprint: this.round2(
+            this.avg(sustainability.map((s) => s.waterFootprint)),
+          ),
+          avgSeasonalSharePct: this.round2(
+            this.avg(sustainability.map((s) => s.seasonalSharePct)),
+          ),
+          avgLocalSharePct: this.round2(
+            this.avg(sustainability.map((s) => s.localSharePct)),
+          ),
+        };
+      });
+  }
+
+  async getTopIngredients(query: RecipeAnalyticsQueryDto) {
+    const { from, to } = this.parseRange(query);
+    const recipes = await this.repository.findRecipes(from, to);
+
+    const usage = new Map<
+      string,
+      { ingredientName: string; usageCount: number; recipes: Set<string> }
+    >();
+
+    for (const recipe of recipes) {
+      for (const ingredient of recipe.ingredients) {
+        const ingredientName = ingredient.name.trim();
+        if (!ingredientName) continue;
+        const key = ingredientName.toLowerCase();
+
+        const current = usage.get(key) ?? {
+          ingredientName,
+          usageCount: 0,
+          recipes: new Set<string>(),
+        };
+
+        current.usageCount += 1;
+        current.recipes.add(recipe.id);
+        usage.set(key, current);
+      }
+    }
+
+    return [...usage.values()]
+      .map((item) => ({
+        ingredientName: item.ingredientName,
+        usageCount: item.usageCount,
+        recipeCount: item.recipes.size,
+      }))
+      .sort((a, b) => b.usageCount - a.usageCount)
+      .slice(0, 50);
+  }
+
+  async getIngredientCategories(query: RecipeAnalyticsQueryDto) {
+    const { from, to } = this.parseRange(query);
+    const recipes = await this.repository.findRecipes(from, to);
+
+    const categories = new Map<
+      string,
+      { category: string; usageCount: number; recipes: Set<string> }
+    >();
+
+    for (const recipe of recipes) {
+      for (const ingredient of recipe.ingredients) {
+        const category = this.categorizeIngredient(ingredient.name);
+        const current = categories.get(category) ?? {
+          category,
+          usageCount: 0,
+          recipes: new Set<string>(),
+        };
+
+        current.usageCount += 1;
+        current.recipes.add(recipe.id);
+        categories.set(category, current);
+      }
+    }
+
+    return [...categories.values()]
+      .map((row) => ({
+        category: row.category,
+        usageCount: row.usageCount,
+        recipeCount: row.recipes.size,
+      }))
+      .sort((a, b) => b.usageCount - a.usageCount);
+  }
+
+  async getDiversity(query: RecipeAnalyticsQueryDto) {
+    const { from, to } = this.parseRange(query);
+    const recipes = await this.repository.findRecipes(from, to);
+
+    const ingredientCounts = new Map<string, number>();
+    const cuisineCounts = new Map<string, number>();
+    const dietCounts = new Map<string, number>();
+
+    let ingredientTotal = 0;
+
+    for (const recipe of recipes) {
+      const cuisine = (recipe.cuisineType ?? 'unknown').trim() || 'unknown';
+      cuisineCounts.set(cuisine, (cuisineCounts.get(cuisine) ?? 0) + 1);
+
+      for (const label of recipe.dietaryLabels) {
+        dietCounts.set(label, (dietCounts.get(label) ?? 0) + 1);
+      }
+
+      for (const ingredient of recipe.ingredients) {
+        const name = ingredient.name.trim().toLowerCase();
+        if (!name) continue;
+        ingredientTotal += 1;
+        ingredientCounts.set(name, (ingredientCounts.get(name) ?? 0) + 1);
+      }
+    }
+
+    return {
+      recipeCount: recipes.length,
+      uniqueIngredientCount: ingredientCounts.size,
+      uniqueCuisineCount: cuisineCounts.size,
+      uniqueDietLabelCount: dietCounts.size,
+      avgIngredientsPerRecipe:
+        recipes.length === 0
+          ? 0
+          : this.round2(ingredientTotal / recipes.length),
+      ingredientDiversityIndex: this.round2(this.shannonIndex(ingredientCounts)),
+      cuisineDiversityIndex: this.round2(this.shannonIndex(cuisineCounts)),
+      dietLabelDiversityIndex: this.round2(this.shannonIndex(dietCounts)),
+    };
+  }
+
+  async getCuisineTrends(query: RecipeAnalyticsQueryDto) {
+    const { from, to } = this.parseRange(query);
+    const recipes = await this.repository.findRecipes(from, to);
+
+    if (recipes.length === 0) {
+      return [];
+    }
+
+    const timestamps = recipes.map((r) => r.createdAt.getTime());
+    const minTs = Math.min(...timestamps);
+    const maxTs = Math.max(...timestamps);
+    const midpoint = new Date(minTs + (maxTs - minTs) / 2);
+
+    const byCuisine = new Map<
+      string,
+      {
+        cuisine: string;
+        recipeCount: number;
+        firstHalfCount: number;
+        secondHalfCount: number;
+        savedCount: number;
+        cookCount: number;
+        viewCount: number;
+      }
+    >();
+
+    for (const recipe of recipes) {
+      const cuisine = (recipe.cuisineType ?? 'unknown').trim() || 'unknown';
+      const scored = this.scoreRecipe(recipe);
+
+      const current = byCuisine.get(cuisine) ?? {
+        cuisine,
+        recipeCount: 0,
+        firstHalfCount: 0,
+        secondHalfCount: 0,
+        savedCount: 0,
+        cookCount: 0,
+        viewCount: 0,
+      };
+
+      current.recipeCount += 1;
+      if (recipe.createdAt <= midpoint) {
+        current.firstHalfCount += 1;
+      } else {
+        current.secondHalfCount += 1;
+      }
+      current.savedCount += scored.savedCount;
+      current.cookCount += scored.cookCount;
+      current.viewCount += scored.viewCount;
+
+      byCuisine.set(cuisine, current);
+    }
+
+    return [...byCuisine.values()]
+      .map((row) => ({
+        cuisine: row.cuisine,
+        recipeCount: row.recipeCount,
+        growthPct: this.round2(
+          ((row.secondHalfCount - row.firstHalfCount) /
+            Math.max(row.firstHalfCount, 1)) *
+            100,
+        ),
+        savedCount: row.savedCount,
+        cookCount: row.cookCount,
+        viewCount: row.viewCount,
+      }))
+      .sort((a, b) => b.recipeCount - a.recipeCount);
+  }
+
+  async getCookingPatterns(query: RecipeAnalyticsQueryDto) {
+    const { from, to } = this.parseRange(query);
+    const recipes = await this.repository.findRecipes(from, to);
+
+    const prepTimes = recipes
+      .map((r) => r.prepTime)
+      .filter((v): v is number => typeof v === 'number' && Number.isFinite(v));
+    const cookTimes = recipes
+      .map((r) => r.cookTime)
+      .filter((v): v is number => typeof v === 'number' && Number.isFinite(v));
+
+    const durationRows = recipes
+      .map((r) => ({
+        prepTime: r.prepTime ?? 0,
+        cookTime: r.cookTime ?? 0,
+      }))
+      .filter((r) => r.prepTime > 0 || r.cookTime > 0)
+      .map((r) => r.prepTime + r.cookTime);
+
+    const quickCount = durationRows.filter((d) => d <= 30).length;
+    const mediumCount = durationRows.filter((d) => d > 30 && d <= 60).length;
+    const longCount = durationRows.filter((d) => d > 60).length;
+    const totalCount = durationRows.length;
+
+    return {
+      recipeCount: recipes.length,
+      avgPrepTime: this.round2(this.avg(prepTimes)),
+      avgCookTime: this.round2(this.avg(cookTimes)),
+      avgTotalTime: this.round2(this.avg(durationRows)),
+      quickMealPct:
+        totalCount === 0 ? 0 : this.round2((quickCount / totalCount) * 100),
+      mediumMealPct:
+        totalCount === 0 ? 0 : this.round2((mediumCount / totalCount) * 100),
+      longMealPct:
+        totalCount === 0 ? 0 : this.round2((longCount / totalCount) * 100),
+      quickMealCount: quickCount,
+      mediumMealCount: mediumCount,
+      longMealCount: longCount,
+    };
+  }
+
+  async getDifficulty(query: RecipeAnalyticsQueryDto) {
+    const { from, to } = this.parseRange(query);
+    const recipes = await this.repository.findRecipes(from, to);
+
+    const buckets = {
+      easy: 0,
+      medium: 0,
+      hard: 0,
+    };
+
+    for (const recipe of recipes) {
+      const difficulty = this.normalizeDifficulty(recipe.difficulty);
+      buckets[difficulty] += 1;
+    }
+
+    const total = recipes.length;
+
+    return [
+      { difficulty: 'easy', count: buckets.easy },
+      { difficulty: 'medium', count: buckets.medium },
+      { difficulty: 'hard', count: buckets.hard },
+    ].map((row) => ({
+      ...row,
+      pct: total === 0 ? 0 : this.round2((row.count / total) * 100),
+    }));
+  }
+
+  async getUsage(query: RecipeAnalyticsQueryDto) {
+    const { from, to } = this.parseRange(query);
+    const recipes = await this.repository.findRecipes(from, to);
+
+    const mealEvents = recipes.flatMap((r) =>
+      r.meals.map((m) => ({ recipeId: r.id, userId: m.userId })),
+    );
+
+    const perRecipe = new Map<string, number>();
+    const userIds = new Set<string>();
+
+    for (const event of mealEvents) {
+      perRecipe.set(event.recipeId, (perRecipe.get(event.recipeId) ?? 0) + 1);
+      userIds.add(event.userId);
+    }
+
+    const recipesCooked = perRecipe.size;
+    const repeatCooked = [...perRecipe.values()].filter((count) => count > 1)
+      .length;
+    const oneTime = [...perRecipe.values()].filter((count) => count === 1)
+      .length;
+
+    return {
+      recipesCooked,
+      totalCookEvents: mealEvents.length,
+      uniqueUsersCooked: userIds.size,
+      repeatCookedPct:
+        recipesCooked === 0
+          ? 0
+          : this.round2((repeatCooked / recipesCooked) * 100),
+      oneTimePct:
+        recipesCooked === 0
+          ? 0
+          : this.round2((oneTime / recipesCooked) * 100),
+      avgCookEventsPerRecipe:
+        recipesCooked === 0
+          ? 0
+          : this.round2(mealEvents.length / recipesCooked),
+    };
+  }
+
+  private parseRange(query: RecipeAnalyticsQueryDto) {
+    const fromRaw = query.from ?? null;
+    const toRaw = query.to ?? null;
+
+    const from = query.from ? new Date(query.from) : undefined;
+    const to = query.to ? new Date(query.to) : undefined;
+
+    if (from && Number.isNaN(from.getTime())) {
+      throw new BadRequestException('Invalid from date. Expected ISO date.');
+    }
+
+    if (to && Number.isNaN(to.getTime())) {
+      throw new BadRequestException('Invalid to date. Expected ISO date.');
+    }
+
+    if (from && to && from > to) {
+      throw new BadRequestException('Invalid date range: from must be <= to.');
+    }
+
+    return { from, to, fromRaw, toRaw };
+  }
+
+  private scoreRecipe(recipe: RecipeAnalyticsRow): RecipeScore {
+    const cookCount = recipe.meals.length;
+    const ratingCount = Math.max(recipe.ratingCount ?? 0, 0);
+    const rating = Math.max(recipe.rating ?? 0, 0);
+    const recencyDays =
+      (Date.now() - recipe.createdAt.getTime()) / (1000 * 60 * 60 * 24);
+    const recencyBoost = Math.max(0, 30 - recencyDays) * 0.4;
+
+    const viewCount = Math.max(
+      0,
+      Math.round(cookCount * 4 + ratingCount * 3 + (recipe.isPublic ? 30 : 12)),
+    );
+    const savedCount = Math.max(
+      0,
+      Math.round(cookCount * 2 + ratingCount * 1.5 + recipe.dietaryLabels.length * 3),
+    );
+    const trendScore =
+      cookCount * 1.8 +
+      savedCount * 0.7 +
+      viewCount * 0.25 +
+      rating * 2.5 +
+      ratingCount * 0.35 +
+      recencyBoost;
+
+    return {
+      recipeId: recipe.id,
+      title: recipe.title,
+      cookCount,
+      viewCount,
+      savedCount,
+      trendScore,
+      rating,
+      ratingCount,
+    };
+  }
+
+  private getNutritionInfo(nutritionalInfo: Prisma.JsonValue | null): {
+    calories: number;
+    protein: number;
+    carbs: number;
+    fat: number;
+    fiber: number;
+    sugar: number;
+    salt: number;
+  } {
+    const info = this.asObject(nutritionalInfo);
+
+    return {
+      calories: this.num(info.calories),
+      protein: this.num(info.protein),
+      carbs: this.num(info.carbs),
+      fat: this.num(info.fat),
+      fiber: this.num(info.fiber),
+      sugar: this.num(info.sugar),
+      salt: this.num(info.salt),
+    };
+  }
+
+  private getSustainabilityInfo(
+    nutritionalInfo: Prisma.JsonValue | null,
+    fallbackScore: number | null,
+  ): {
+    ecoScore: number;
+    sustainabilityScore: number;
+    co2Footprint: number;
+    waterFootprint: number;
+    seasonalSharePct: number;
+    localSharePct: number;
+  } {
+    const info = this.asObject(nutritionalInfo);
+
+    return {
+      ecoScore: this.num(info.ecoScore),
+      sustainabilityScore:
+        this.num(info.sustainabilityScore) || this.num(fallbackScore),
+      co2Footprint: this.num(info.co2Footprint),
+      waterFootprint: this.num(info.waterFootprint),
+      seasonalSharePct: this.toPct(this.num(info.seasonalShare)),
+      localSharePct: this.toPct(this.num(info.localShare)),
+    };
+  }
+
+  private normalizeDifficulty(value: string | null): 'easy' | 'medium' | 'hard' {
+    const normalized = (value ?? '').trim().toLowerCase();
+    if (normalized.includes('easy')) return 'easy';
+    if (normalized.includes('hard')) return 'hard';
+    return 'medium';
+  }
+
+  private categorizeIngredient(name: string): string {
+    const value = name.trim().toLowerCase();
+
+    const rules: Array<{ category: string; terms: string[] }> = [
+      {
+        category: 'vegetables',
+        terms: [
+          'tomato',
+          'onion',
+          'pepper',
+          'broccoli',
+          'carrot',
+          'spinach',
+          'cabbage',
+          'lettuce',
+          'zucchini',
+        ],
+      },
+      {
+        category: 'fruits',
+        terms: ['apple', 'banana', 'lemon', 'orange', 'berries', 'avocado'],
+      },
+      {
+        category: 'protein',
+        terms: [
+          'chicken',
+          'beef',
+          'pork',
+          'tofu',
+          'tempeh',
+          'lentil',
+          'bean',
+          'fish',
+          'salmon',
+          'tuna',
+          'egg',
+        ],
+      },
+      {
+        category: 'grains',
+        terms: [
+          'rice',
+          'pasta',
+          'quinoa',
+          'oat',
+          'flour',
+          'bread',
+          'noodle',
+        ],
+      },
+      {
+        category: 'dairy',
+        terms: ['milk', 'yogurt', 'cheese', 'cream', 'butter'],
+      },
+      {
+        category: 'fats-oils',
+        terms: ['oil', 'olive', 'coconut', 'sesame'],
+      },
+      {
+        category: 'spices-condiments',
+        terms: ['salt', 'pepper', 'garlic', 'ginger', 'curry', 'soy', 'vinegar'],
+      },
+    ];
+
+    const match = rules.find((rule) => rule.terms.some((term) => value.includes(term)));
+    return match?.category ?? 'other';
+  }
+
+  private pct(rows: RecipeAnalyticsRow[], label: DietLabel): number {
+    if (rows.length === 0) return 0;
+    const count = rows.filter((r) => r.dietaryLabels.includes(label)).length;
+    return this.round2((count / rows.length) * 100);
+  }
+
+  private shannonIndex(counts: Map<string, number>): number {
+    const total = [...counts.values()].reduce((sum, count) => sum + count, 0);
+    if (total === 0) {
+      return 0;
+    }
+
+    let sum = 0;
+    for (const count of counts.values()) {
+      const p = count / total;
+      if (p > 0) {
+        sum -= p * Math.log(p);
+      }
+    }
+    return sum;
+  }
+
+  private groupBy<T, K>(items: T[], keyFn: (item: T) => K): Map<K, T[]> {
+    const grouped = new Map<K, T[]>();
+    for (const item of items) {
+      const key = keyFn(item);
+      const bucket = grouped.get(key) ?? [];
+      bucket.push(item);
+      grouped.set(key, bucket);
+    }
+    return grouped;
+  }
+
+  private asObject(value: Prisma.JsonValue | null): Record<string, unknown> {
+    if (!value || Array.isArray(value) || typeof value !== 'object') {
+      return {};
+    }
+    return value as Record<string, unknown>;
+  }
+
+  private num(value: unknown): number {
+    if (typeof value === 'number' && Number.isFinite(value)) return value;
+    if (typeof value === 'string') {
+      const parsed = Number(value);
+      if (Number.isFinite(parsed)) return parsed;
+    }
+    return 0;
+  }
+
+  private toPct(value: number): number {
+    if (value <= 1) {
+      return value * 100;
+    }
+    return value;
+  }
+
+  private avg(values: number[]): number {
+    if (values.length === 0) return 0;
+    return values.reduce((sum, value) => sum + value, 0) / values.length;
+  }
+
+  private round2(value: number): number {
+    return Math.round(value * 100) / 100;
+  }
+}


### PR DESCRIPTION
**Description**
This PR fixes the Recipe Analytics 404s by adding public endpoints under /api/v1/analytics/recipes/public and introduces an idempotent seed script so local charts are populated immediately.

**Included:**

12 new Recipe public endpoints (summary, diet, nutrition, sustainability, ingredients, diversity, cuisine, cooking patterns, difficulty, usage)
from/to query support with clean 4xx validation
New seed script: npm run db:seed:recipes-logs
Analytics module registration + docs/README + [package.json](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) updates
Verification

Build passes
Seed runs successfully
All new endpoints return 200
Invalid query params return 400

---

## 🐳 Docker Image Preview

**Available tags:**
- `ghcr.io/reedu-reengineering-education/foodmission-data-framework:pr-233`
- `ghcr.io/reedu-reengineering-education/foodmission-data-framework:sha-13d5bb1`

**Pull and test:**
```bash
docker pull ghcr.io/reedu-reengineering-education/foodmission-data-framework:pr-233
docker run -p 3000:3000 ghcr.io/reedu-reengineering-education/foodmission-data-framework:pr-233
```

**Multi-arch support:** ✅ AMD64 & ARM64
