### PR TITLE
feat: add slug to food groups response

### DIFF
--- a/src/generic-foods/controllers/generic-foods.controller.spec.ts
+++ b/src/generic-foods/controllers/generic-foods.controller.spec.ts
@@ -173,7 +173,12 @@ describe('GenericFoodsController', () => {
 
   describe('getAllFoodGroups', () => {
     it('should return all unique food groups', async () => {
-      const foodGroups = ['Vegetables', 'Fruits', 'Grains', 'Dairy'];
+      const foodGroups = [
+        { slug: 'vegetables', name: 'Vegetables' },
+        { slug: 'fruits', name: 'Fruits' },
+        { slug: 'grains', name: 'Grains' },
+        { slug: 'dairy', name: 'Dairy' },
+      ];
       service.getAllFoodGroups.mockResolvedValue(foodGroups);
 
       const result = await controller.getAllFoodGroups({});
@@ -187,7 +192,10 @@ describe('GenericFoodsController', () => {
     });
 
     it('should return filtered food groups when search is provided', async () => {
-      const foodGroups = ['Vegetables', 'Vegetable oils'];
+      const foodGroups = [
+        { slug: 'vegetables', name: 'Vegetables' },
+        { slug: 'vegetable-oils', name: 'Vegetable oils' },
+      ];
       service.getAllFoodGroups.mockResolvedValue(foodGroups);
 
       const result = await controller.getAllFoodGroups({ search: 'vegeta' });

--- a/src/generic-foods/controllers/generic-foods.controller.ts
+++ b/src/generic-foods/controllers/generic-foods.controller.ts
@@ -26,6 +26,7 @@ import { UpdateGenericFoodDto } from '../dto/update-generic-food.dto';
 import { GenericFoodQueryDto } from '../dto/generic-food-query.dto';
 import { FoodGroupsQueryDto } from '../dto/food-groups-query.dto';
 import { GenericFoodResponseDto } from '../dto/generic-food-response.dto';
+import { FoodGroupResponseDto } from '../dto/food-group-response.dto';
 import { DEFAULT_LOCALE, SUPPORTED_LOCALES } from '../../i18n/constants';
 
 @ApiTags('generic-foods')
@@ -90,14 +91,16 @@ export class GenericFoodsController {
   @ApiOperation({
     summary: 'Get all unique food groups',
     description:
-      'Get a list of all distinct food groups available, optionally filtered by search term and localized via lang',
+      'Get distinct food groups with a stable English-derived slug (for icon matching) and a localized display name',
   })
   @ApiResponse({
     status: 200,
     description: 'Food groups retrieved successfully',
-    type: [String],
+    type: [FoodGroupResponseDto],
   })
-  getAllFoodGroups(@Query() query: FoodGroupsQueryDto): Promise<string[]> {
+  getAllFoodGroups(
+    @Query() query: FoodGroupsQueryDto,
+  ): Promise<FoodGroupResponseDto[]> {
     return this.genericFoodService.getAllFoodGroups(query.search, query.lang);
   }
 

--- a/src/generic-foods/dto/food-group-response.dto.ts
+++ b/src/generic-foods/dto/food-group-response.dto.ts
@@ -1,0 +1,16 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class FoodGroupResponseDto {
+  @ApiProperty({
+    description:
+      'Stable slug derived from the English food group label (for icon matching)',
+    example: 'potatoes-and-tubers',
+  })
+  slug: string;
+
+  @ApiProperty({
+    description: 'Localized food group display name',
+    example: 'Potatoes and tubers',
+  })
+  name: string;
+}

--- a/src/generic-foods/dto/generic-food-response.dto.ts
+++ b/src/generic-foods/dto/generic-food-response.dto.ts
@@ -14,10 +14,17 @@ export class GenericFoodResponseDto {
   nevoVersion: string;
 
   @ApiProperty({
-    description: 'Food group',
+    description: 'Food group (localized when lang is set)',
     example: 'Potatoes and tubers',
   })
   foodGroup: string;
+
+  @ApiProperty({
+    description:
+      'Stable slug derived from the English food group (for icon matching across locales)',
+    example: 'potatoes-and-tubers',
+  })
+  foodGroupSlug: string;
 
   @ApiProperty({ description: 'NEVO food code', example: 100 })
   nevoCode: number;

--- a/src/generic-foods/repositories/generic-food.repository.ts
+++ b/src/generic-foods/repositories/generic-food.repository.ts
@@ -138,7 +138,7 @@ export class GenericFoodRepository {
     const result = await this.prisma.genericFood.findMany({
       select: { id: true, foodGroup: true },
       distinct: ['foodGroup'],
-      orderBy: { foodGroup: 'asc' },
+      orderBy: [{ foodGroup: 'asc' }, { id: 'asc' }],
     });
 
     return result.map((r) => ({

--- a/src/generic-foods/repositories/generic-food.repository.ts
+++ b/src/generic-foods/repositories/generic-food.repository.ts
@@ -128,20 +128,22 @@ export class GenericFoodRepository {
     });
   }
 
-  async getAllFoodGroups(search?: string): Promise<string[]> {
-    const where: Prisma.GenericFoodWhereInput = {};
-
-    if (search) {
-      where.foodGroup = { contains: search, mode: 'insensitive' };
-    }
-
+  /**
+   * Distinct English food groups with one sample entity id each
+   * (for resolving localized group labels).
+   */
+  async getDistinctFoodGroups(): Promise<
+    { foodGroup: string; sampleId: string }[]
+  > {
     const result = await this.prisma.genericFood.findMany({
-      where,
-      select: { foodGroup: true },
+      select: { id: true, foodGroup: true },
       distinct: ['foodGroup'],
       orderBy: { foodGroup: 'asc' },
     });
 
-    return result.map((r) => r.foodGroup);
+    return result.map((r) => ({
+      foodGroup: r.foodGroup,
+      sampleId: r.id,
+    }));
   }
 }

--- a/src/generic-foods/services/generic-food.service.spec.ts
+++ b/src/generic-foods/services/generic-food.service.spec.ts
@@ -22,14 +22,13 @@ describe('GenericFoodService', () => {
     update: jest.fn(),
     delete: jest.fn(),
     findByNevoCode: jest.fn(),
-    getAllFoodGroups: jest.fn(),
+    getDistinctFoodGroups: jest.fn(),
   };
 
   const mockTranslationMethods = {
     resolveLocale: jest.fn((lang?: string) => lang ?? 'en'),
     resolveMany: jest.fn(),
     findEntityIdsByValue: jest.fn(),
-    listDistinct: jest.fn(),
     deleteForEntity: jest.fn(),
   };
 
@@ -73,7 +72,10 @@ describe('GenericFoodService', () => {
       const result = await service.create(createDto);
 
       expect(repository.create).toHaveBeenCalledWith(createDto);
-      expect(result).toEqual(mockCategory);
+      expect(result).toEqual({
+        ...mockCategory,
+        foodGroupSlug: 'vegetables',
+      });
     });
   });
 
@@ -99,6 +101,7 @@ describe('GenericFoodService', () => {
 
       expect(repository.findAll).toHaveBeenCalledWith(query, undefined);
       expect(result.items[0].foodName).toBe(mockCategory.foodName);
+      expect(result.items[0].foodGroupSlug).toBe('vegetables');
       expect(result.items[0].remark).toBeNull();
     });
 
@@ -126,6 +129,7 @@ describe('GenericFoodService', () => {
 
       expect(result.items[0].foodName).toBe('Tomaat rauw');
       expect(result.items[0].foodGroup).toBe('Groenten');
+      expect(result.items[0].foodGroupSlug).toBe('vegetables');
     });
 
     it('should search localized names when lang is set', async () => {
@@ -216,6 +220,7 @@ describe('GenericFoodService', () => {
 
       expect(repository.findById).toHaveBeenCalledWith('generic-123');
       expect(result.id).toBe('generic-123');
+      expect(result.foodGroupSlug).toBe('vegetables');
       expect(result.remark).toBeNull();
     });
 
@@ -270,29 +275,57 @@ describe('GenericFoodService', () => {
   });
 
   describe('getAllFoodGroups', () => {
-    it('should return English groups by default', async () => {
+    it('should return English groups with slugs by default', async () => {
       translations.resolveLocale.mockReturnValue('en');
-      repository.getAllFoodGroups.mockResolvedValue(['Vegetables']);
+      repository.getDistinctFoodGroups.mockResolvedValue([
+        { foodGroup: 'Vegetables', sampleId: 'sample-1' },
+        { foodGroup: 'Milk and milk products', sampleId: 'sample-2' },
+      ]);
 
       const result = await service.getAllFoodGroups();
 
-      expect(repository.getAllFoodGroups).toHaveBeenCalledWith(undefined);
-      expect(result).toEqual(['Vegetables']);
+      expect(repository.getDistinctFoodGroups).toHaveBeenCalled();
+      expect(result).toEqual([
+        { slug: 'vegetables', name: 'Vegetables' },
+        { slug: 'milk-and-milk-products', name: 'Milk and milk products' },
+      ]);
     });
 
-    it('should return localized groups when available', async () => {
+    it('should return localized names with English-derived slugs', async () => {
       translations.resolveLocale.mockReturnValue('nl');
-      translations.listDistinct.mockResolvedValue(['Groenten']);
+      repository.getDistinctFoodGroups.mockResolvedValue([
+        { foodGroup: 'Vegetables', sampleId: 'sample-1' },
+      ]);
+      translations.resolveMany.mockResolvedValue({
+        'sample-1': { foodGroup: 'Groenten' },
+      });
 
       const result = await service.getAllFoodGroups(undefined, 'nl');
 
-      expect(translations.listDistinct).toHaveBeenCalledWith(
+      expect(translations.resolveMany).toHaveBeenCalledWith(
         'GenericFood',
+        ['sample-1'],
         'nl',
-        'foodGroup',
-        undefined,
+        ['foodGroup'],
+        { 'sample-1': { foodGroup: 'Vegetables' } },
       );
-      expect(result).toEqual(['Groenten']);
+      expect(result).toEqual([{ slug: 'vegetables', name: 'Groenten' }]);
+    });
+
+    it('should filter by localized name when search is provided', async () => {
+      translations.resolveLocale.mockReturnValue('nl');
+      repository.getDistinctFoodGroups.mockResolvedValue([
+        { foodGroup: 'Vegetables', sampleId: 'sample-1' },
+        { foodGroup: 'Fruits', sampleId: 'sample-2' },
+      ]);
+      translations.resolveMany.mockResolvedValue({
+        'sample-1': { foodGroup: 'Groenten' },
+        'sample-2': { foodGroup: 'Fruit' },
+      });
+
+      const result = await service.getAllFoodGroups('groen', 'nl');
+
+      expect(result).toEqual([{ slug: 'vegetables', name: 'Groenten' }]);
     });
   });
 });

--- a/src/generic-foods/services/generic-food.service.ts
+++ b/src/generic-foods/services/generic-food.service.ts
@@ -1,11 +1,13 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
 import { GenericFoodRepository } from '../repositories/generic-food.repository';
 import { GenericFoodResponseDto } from '../dto/generic-food-response.dto';
+import { FoodGroupResponseDto } from '../dto/food-group-response.dto';
 import { CreateGenericFoodDto } from '../dto/create-generic-food.dto';
 import { UpdateGenericFoodDto } from '../dto/update-generic-food.dto';
 import { GenericFoodQueryDto } from '../dto/generic-food-query.dto';
 import { TranslationService } from '../../translations/services/translation.service';
 import { DEFAULT_LOCALE } from '../../i18n/constants';
+import { toFoodGroupSlug } from '../utils/food-group-slug.util';
 import type { GenericFood } from '@prisma/client';
 
 const GENERIC_FOOD_TRANSLATABLE_FIELDS = [
@@ -26,7 +28,7 @@ export class GenericFoodService {
     createDto: CreateGenericFoodDto,
   ): Promise<GenericFoodResponseDto> {
     const category = await this.genericFoodRepository.create(createDto);
-    return category;
+    return this.toResponse(category);
   }
 
   async findAll(query: GenericFoodQueryDto) {
@@ -92,7 +94,7 @@ export class GenericFoodService {
     await this.findById(id);
 
     const updated = await this.genericFoodRepository.update(id, updateDto);
-    return updated;
+    return this.toResponse(updated);
   }
 
   async delete(id: string): Promise<void> {
@@ -101,37 +103,70 @@ export class GenericFoodService {
     await this.genericFoodRepository.delete(id);
   }
 
-  async getAllFoodGroups(search?: string, lang?: string): Promise<string[]> {
+  async getAllFoodGroups(
+    search?: string,
+    lang?: string,
+  ): Promise<FoodGroupResponseDto[]> {
     const locale = this.translationService.resolveLocale(lang);
+    const groups = await this.genericFoodRepository.getDistinctFoodGroups();
+
+    let result: FoodGroupResponseDto[];
 
     if (locale === DEFAULT_LOCALE) {
-      return this.genericFoodRepository.getAllFoodGroups(search);
+      result = groups.map(({ foodGroup }) => ({
+        slug: toFoodGroupSlug(foodGroup),
+        name: foodGroup,
+      }));
+    } else {
+      const sampleIds = groups.map((g) => g.sampleId);
+      const fallbackById = Object.fromEntries(
+        groups.map((g) => [g.sampleId, { foodGroup: g.foodGroup }]),
+      );
+
+      const localized = await this.translationService.resolveMany(
+        'GenericFood',
+        sampleIds,
+        locale,
+        ['foodGroup'],
+        fallbackById,
+      );
+
+      result = groups.map(({ foodGroup, sampleId }) => ({
+        slug: toFoodGroupSlug(foodGroup),
+        name: localized[sampleId]?.foodGroup ?? foodGroup,
+      }));
     }
 
-    const translated = await this.translationService.listDistinct(
-      'GenericFood',
-      locale,
-      'foodGroup',
-      search,
-    );
-
-    if (translated.length > 0) {
-      return translated;
+    if (search?.trim()) {
+      const q = search.trim().toLowerCase();
+      result = result.filter((g) => g.name.toLowerCase().includes(q));
     }
 
-    return this.genericFoodRepository.getAllFoodGroups(search);
+    return result;
+  }
+
+  private toResponse(
+    item: GenericFood & { remark?: string | null },
+  ): GenericFoodResponseDto {
+    return {
+      ...item,
+      foodGroupSlug: toFoodGroupSlug(item.foodGroup),
+    };
   }
 
   private async overlayTranslations(
     items: GenericFood[],
     locale: string,
-  ): Promise<(GenericFood & { remark?: string | null })[]> {
+  ): Promise<GenericFoodResponseDto[]> {
     if (items.length === 0) {
-      return items;
+      return [];
     }
 
     if (locale === DEFAULT_LOCALE) {
-      return items.map((item) => ({ ...item, remark: null }));
+      return items.map((item) => ({
+        ...this.toResponse(item),
+        remark: null,
+      }));
     }
 
     const fallbackById = Object.fromEntries(
@@ -158,6 +193,7 @@ export class GenericFoodService {
       const overlay = localized[item.id] ?? {};
       return {
         ...item,
+        foodGroupSlug: toFoodGroupSlug(item.foodGroup),
         foodName: overlay.foodName ?? item.foodName,
         foodGroup: overlay.foodGroup ?? item.foodGroup,
         synonym: overlay.synonym ?? item.synonym,

--- a/src/generic-foods/utils/food-group-slug.util.spec.ts
+++ b/src/generic-foods/utils/food-group-slug.util.spec.ts
@@ -1,0 +1,28 @@
+import { toFoodGroupSlug } from './food-group-slug.util';
+
+describe('toFoodGroupSlug', () => {
+  it('lowercases a single word', () => {
+    expect(toFoodGroupSlug('Vegetables')).toBe('vegetables');
+  });
+
+  it('kebab-cases spaces and conjunctions', () => {
+    expect(toFoodGroupSlug('Milk and milk products')).toBe(
+      'milk-and-milk-products',
+    );
+  });
+
+  it('replaces slashes and other punctuation', () => {
+    expect(toFoodGroupSlug('Fish/crustacean/shellfish')).toBe(
+      'fish-crustacean-shellfish',
+    );
+  });
+
+  it('collapses repeated separators and trims edges', () => {
+    expect(toFoodGroupSlug('  Potatoes and tubers  ')).toBe(
+      'potatoes-and-tubers',
+    );
+    expect(toFoodGroupSlug('Sugar/sweets/sweet sauces')).toBe(
+      'sugar-sweets-sweet-sauces',
+    );
+  });
+});

--- a/src/generic-foods/utils/food-group-slug.util.ts
+++ b/src/generic-foods/utils/food-group-slug.util.ts
@@ -1,0 +1,16 @@
+/**
+ * Derives a stable kebab-case slug from the English NEVO foodGroup label.
+ * Used for icon matching across locales — always pass the English parent value.
+ *
+ * Examples:
+ *   "Vegetables" → "vegetables"
+ *   "Milk and milk products" → "milk-and-milk-products"
+ *   "Fish/crustacean/shellfish" → "fish-crustacean-shellfish"
+ */
+export function toFoodGroupSlug(englishFoodGroup: string): string {
+  return englishFoodGroup
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}

--- a/test/e2e/generic-foods.e2e-spec.ts
+++ b/test/e2e/generic-foods.e2e-spec.ts
@@ -111,7 +111,12 @@ describe('GenericFoods endpoints (e2e)', () => {
       .get('/generic-foods/food-groups')
       .expect(200);
     expect(Array.isArray(res.body)).toBe(true);
-    expect(res.body).toEqual(expect.arrayContaining(['Fruit', 'Vegetables']));
+    expect(res.body).toEqual(
+      expect.arrayContaining([
+        { slug: 'fruit', name: 'Fruit' },
+        { slug: 'vegetables', name: 'Vegetables' },
+      ]),
+    );
   });
 
   itIfDb('GET /generic-foods/:id returns one generic food', async () => {
@@ -119,6 +124,7 @@ describe('GenericFoods endpoints (e2e)', () => {
       .get('/generic-foods/00000000-0000-0000-0000-000000000301')
       .expect(200);
     expect(res.body.nevoCode).toBe(900001);
+    expect(res.body.foodGroupSlug).toBe('fruit');
   });
 
   itIfDb('GET /generic-foods?lang=nl overlays Dutch translations', async () => {
@@ -147,6 +153,7 @@ describe('GenericFoods endpoints (e2e)', () => {
 
     expect(res.body.foodName).toBe('Appel rauw');
     expect(res.body.foodGroup).toBe('Fruit (NL)');
+    expect(res.body.foodGroupSlug).toBe('fruit');
   });
 
   itIfDb('GET /generic-foods search works with localized names', async () => {


### PR DESCRIPTION
# Pull Request

## Description

Add a stable English-derived `slug` for NEVO food groups so the UI can map icons across locales. `GET /generic-foods/food-groups` previously returned translated label strings only, which broke icon matching when `?lang=` changed.

## Type of Change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Type of Changes

- [x] API changes

## Changes Made

- `GET /generic-foods/food-groups` now returns `{ slug, name }[]` instead of `string[]`
  - `slug` — kebab-case from the English `foodGroup` (stable across locales)
  - `name` — localized display label
- Generic food item responses include `foodGroupSlug` (same derivation)
- Shared helper `toFoodGroupSlug()`; no schema/migration

**Breaking:** clients consuming food-groups as `string[]` must switch to objects.

Example (`?lang=nl`):
```json
[{ "slug": "vegetables", "name": "Groenten" }]

---

## 🐳 Docker Image Preview

**Available tags:**
- `ghcr.io/reedu-reengineering-education/foodmission-data-framework:pr-263`
- `ghcr.io/reedu-reengineering-education/foodmission-data-framework:sha-ed05039`

**Pull and test:**
```bash
docker pull ghcr.io/reedu-reengineering-education/foodmission-data-framework:pr-263
docker run -p 3000:3000 ghcr.io/reedu-reengineering-education/foodmission-data-framework:pr-263
```

**Multi-arch support:** ✅ AMD64 & ARM64
