### PR TITLE
feat: allow multiple item creation for the same food in pantry

### DIFF
--- a/prisma/migrations/20260726200000_allow_duplicate_pantry_items/migration.sql
+++ b/prisma/migrations/20260726200000_allow_duplicate_pantry_items/migration.sql
@@ -2,3 +2,7 @@
 -- (e.g. same product with different expiration dates)
 DROP INDEX IF EXISTS "pantry_items_pantryId_foodProductId_key";
 DROP INDEX IF EXISTS "pantry_items_pantryId_genericFoodId_key";
+
+-- Keep composite indexes for queries filtering by both columns together
+CREATE INDEX "pantry_items_pantryId_foodProductId_idx" ON "pantry_items"("pantryId", "foodProductId");
+CREATE INDEX "pantry_items_pantryId_genericFoodId_idx" ON "pantry_items"("pantryId", "genericFoodId");

--- a/prisma/migrations/20260726200000_allow_duplicate_pantry_items/migration.sql
+++ b/prisma/migrations/20260726200000_allow_duplicate_pantry_items/migration.sql
@@ -1,0 +1,4 @@
+-- Allow multiple pantry items for the same food product / generic food
+-- (e.g. same product with different expiration dates)
+DROP INDEX IF EXISTS "pantry_items_pantryId_foodProductId_key";
+DROP INDEX IF EXISTS "pantry_items_pantryId_genericFoodId_key";

--- a/prisma/models/shopping.prisma
+++ b/prisma/models/shopping.prisma
@@ -92,8 +92,6 @@ model PantryItem {
   genericFood  GenericFood?  @relation(fields: [genericFoodId], references: [id], onDelete: SetNull)
   foodWaste    FoodWaste[]
 
-  @@unique([pantryId, foodProductId])
-  @@unique([pantryId, genericFoodId])
   @@index([pantryId])
   @@index([foodProductId])
   @@index([genericFoodId])

--- a/prisma/models/shopping.prisma
+++ b/prisma/models/shopping.prisma
@@ -95,6 +95,8 @@ model PantryItem {
   @@index([pantryId])
   @@index([foodProductId])
   @@index([genericFoodId])
+  @@index([pantryId, foodProductId])
+  @@index([pantryId, genericFoodId])
   @@index([expiryDate])
   @@map("pantry_items")
 }

--- a/src/pantry/repositories/pantry-items.repository.spec.ts
+++ b/src/pantry/repositories/pantry-items.repository.spec.ts
@@ -131,29 +131,6 @@ describe('PantryItemRepository', () => {
       expect(result.expiryDate).toBeNull();
     });
 
-    it('should throw Prisma unique constraint error when food already exists in pantry', async () => {
-      const createData = {
-        pantryId: TEST_IDS.PANTRY,
-        foodProductId: TEST_IDS.FOOD,
-        genericFoodId: null,
-        itemType: 'food_product',
-        quantity: TEST_DATA.QUANTITY,
-        unit: Unit.KG,
-      };
-
-      const prismaError = new Prisma.PrismaClientKnownRequestError(
-        'Unique constraint failed',
-        {
-          code: 'P2002',
-          clientVersion: '4.0.0',
-          meta: { target: ['pantryId', 'foodProductId'] },
-        },
-      );
-      mockPrismaService.pantryItem.create.mockRejectedValue(prismaError);
-
-      await expect(repository.create(createData)).rejects.toThrow(prismaError);
-    });
-
     it('should throw error when creation fails', async () => {
       const createData = {
         pantryId: TEST_IDS.PANTRY,
@@ -370,27 +347,6 @@ describe('PantryItemRepository', () => {
       ).rejects.toThrow(prismaError);
     });
 
-    it('should throw Prisma unique constraint error when updating to duplicate food', async () => {
-      const updateData: Prisma.PantryItemUpdateInput = {
-        foodProduct: {
-          connect: { id: 'duplicate-food-id' },
-        },
-      };
-      const prismaError = new Prisma.PrismaClientKnownRequestError(
-        'Unique constraint failed',
-        {
-          code: 'P2002',
-          clientVersion: '4.0.0',
-          meta: { target: ['pantryId', 'foodProductId'] },
-        },
-      );
-      mockPrismaService.pantryItem.update.mockRejectedValue(prismaError);
-
-      await expect(
-        repository.update(TEST_IDS.PANTRY_ITEM, updateData),
-      ).rejects.toThrow(prismaError);
-    });
-
     it('should throw error when update fails', async () => {
       const updateData = {
         quantity: 10,
@@ -435,41 +391,6 @@ describe('PantryItemRepository', () => {
       await expect(repository.delete(TEST_IDS.PANTRY_ITEM)).rejects.toThrow(
         dbError,
       );
-    });
-  });
-
-  describe('findFoodProductInPantry', () => {
-    it('should find a specific food product item in a pantry', async () => {
-      mockPrismaService.pantryItem.findFirst.mockResolvedValue(mockPantryItem);
-
-      const result = await repository.findFoodProductInPantry(
-        TEST_IDS.PANTRY,
-        TEST_IDS.FOOD,
-      );
-
-      expect(result).toEqual(mockPantryItem);
-      expect(prisma.pantryItem.findFirst).toHaveBeenCalledWith({
-        where: {
-          pantryId: TEST_IDS.PANTRY,
-          foodProductId: TEST_IDS.FOOD,
-        },
-        include: {
-          pantry: true,
-          foodProduct: true,
-          genericFood: true,
-        },
-      });
-    });
-
-    it('should return null if food product not found in pantry', async () => {
-      mockPrismaService.pantryItem.findFirst.mockResolvedValue(null);
-
-      const result = await repository.findFoodProductInPantry(
-        TEST_IDS.PANTRY,
-        'food-999',
-      );
-
-      expect(result).toBeNull();
     });
   });
 });

--- a/src/pantry/repositories/pantry-items.repository.ts
+++ b/src/pantry/repositories/pantry-items.repository.ts
@@ -106,35 +106,5 @@ export class PantryItemRepository {
       where: { id },
     });
   }
-
-  async findFoodProductInPantry(
-    pantryId: string,
-    foodProductId: string,
-    tx?: Prisma.TransactionClient,
-  ): Promise<PantryItemWithRelations | null> {
-    const client = tx ?? this.prisma;
-    return await client.pantryItem.findFirst({
-      where: {
-        pantryId: pantryId,
-        foodProductId: foodProductId,
-      },
-      include: PANTRY_ITEM_WITH_RELATIONS_INCLUDE,
-    });
-  }
-
-  async findGenericFoodInPantry(
-    pantryId: string,
-    genericFoodId: string,
-    tx?: Prisma.TransactionClient,
-  ): Promise<PantryItemWithRelations | null> {
-    const client = tx ?? this.prisma;
-    return await client.pantryItem.findFirst({
-      where: {
-        pantryId: pantryId,
-        genericFoodId: genericFoodId,
-      },
-      include: PANTRY_ITEM_WITH_RELATIONS_INCLUDE,
-    });
-  }
 }
 export { PantryItemWithRelations };

--- a/src/pantry/services/pantry-items.service.spec.ts
+++ b/src/pantry/services/pantry-items.service.spec.ts
@@ -1,16 +1,9 @@
-import { Test, TestingModule } from '@nestjs/testing';
-import { PantryItemService } from './pantry-items.service';
-import { PantryItemRepository } from '../repositories/pantry-items.repository';
-import { PantryService } from './pantry.service';
 import {
   BadRequestException,
-  ConflictException,
   ForbiddenException,
   NotFoundException,
 } from '@nestjs/common';
 import { Unit } from '@prisma/client';
-import { PrismaClientKnownRequestError } from '@prisma/client/runtime/library';
-import { ERROR_CODES } from '../../common/utils/error.utils';
 import { CreateShoppingListItemDto } from '../../shopping-lists/dto/create-shopping-list-item.dto';
 import { CreatePantryItemDto } from '../dto/create-pantry-item.dto';
 import { UpdatePantryItemDto } from '../dto/update-pantry-item.dto';
@@ -28,6 +21,10 @@ import {
   createMockPantryItemWithRelations,
   setupSuccessfulCreateMocks,
 } from '../test-utils/pantry-items-mocks';
+import { PantryItemService } from './pantry-items.service';
+import { PantryItemRepository } from '../repositories/pantry-items.repository';
+import { PantryService } from './pantry.service';
+import { Test, TestingModule } from '@nestjs/testing';
 
 describe('PantryItemService', () => {
   let service: PantryItemService;
@@ -90,7 +87,6 @@ describe('PantryItemService', () => {
       setupSuccessfulCreateMocks({
         mockPantryService,
         mockFoodRepository,
-        mockPantryItemRepository,
       });
       mockPantryItemRepository.create.mockResolvedValue(mockPantryItem);
 
@@ -101,7 +97,6 @@ describe('PantryItemService', () => {
       expect(result.pantryId).toBe(TEST_IDS.PANTRY);
       expect(pantryService.validatePantryExists).toHaveBeenCalled();
       expect(mockFoodRepository.findById).toHaveBeenCalled();
-      expect(repository.findFoodProductInPantry).toHaveBeenCalled();
       expect(mockPantryItemRepository.create).toHaveBeenCalled();
     });
 
@@ -115,21 +110,29 @@ describe('PantryItemService', () => {
       );
     });
 
-    it('should throw ConflictException when food already exists in pantry', async () => {
-      const createDto = PantryItemsTestBuilder.createCreatePantryItemDto();
-      const mockPantryItem = createMockPantryItemWithRelations();
-      mockPantryService.validatePantryExists.mockResolvedValue(TEST_IDS.PANTRY);
-      mockFoodRepository.findById.mockResolvedValue({
-        id: TEST_IDS.FOOD,
-        name: 'Tomatoes',
+    it('should allow creating a duplicate food product in the pantry', async () => {
+      const createDto = PantryItemsTestBuilder.createCreatePantryItemDto({
+        expiryDate: new Date('2027-01-15'),
       });
-      mockPantryItemRepository.findFoodProductInPantry.mockResolvedValue(
-        mockPantryItem,
+      const mockPantryItem = createMockPantryItemWithRelations();
+      setupSuccessfulCreateMocks({
+        mockPantryService,
+        mockFoodRepository,
+      });
+      mockPantryItemRepository.create.mockResolvedValue(mockPantryItem);
+
+      const first = await service.create(createDto, userId);
+      const second = await service.create(
+        {
+          ...createDto,
+          expiryDate: new Date('2027-02-20'),
+        },
+        userId,
       );
 
-      await expect(service.create(createDto, userId)).rejects.toThrow(
-        ConflictException,
-      );
+      expect(first.id).toBe(TEST_IDS.PANTRY_ITEM);
+      expect(second.id).toBe(TEST_IDS.PANTRY_ITEM);
+      expect(mockPantryItemRepository.create).toHaveBeenCalledTimes(2);
     });
 
     it('should throw BadRequestException when creation fails unexpectedly', async () => {
@@ -137,7 +140,6 @@ describe('PantryItemService', () => {
       setupSuccessfulCreateMocks({
         mockPantryService,
         mockFoodRepository,
-        mockPantryItemRepository,
       });
       mockPantryItemRepository.create.mockRejectedValue(new Error('DB Error'));
 
@@ -158,7 +160,6 @@ describe('PantryItemService', () => {
       setupSuccessfulCreateMocks({
         mockPantryService,
         mockFoodRepository,
-        mockPantryItemRepository,
       });
       mockPantryItemRepository.create.mockResolvedValue(mockPantryItem);
 
@@ -183,7 +184,6 @@ describe('PantryItemService', () => {
       setupSuccessfulCreateMocks({
         mockPantryService,
         mockFoodRepository,
-        mockPantryItemRepository,
       });
       mockPantryItemRepository.create.mockResolvedValue({
         ...mockPantryItem,
@@ -203,7 +203,6 @@ describe('PantryItemService', () => {
       setupSuccessfulCreateMocks({
         mockPantryService,
         mockFoodRepository,
-        mockPantryItemRepository,
       });
       mockPantryItemRepository.create.mockResolvedValue({
         ...mockPantryItem,
@@ -237,9 +236,6 @@ describe('PantryItemService', () => {
               : SHELF_LIFE_ID,
           categories: overrides.categories ?? [],
         });
-        mockPantryItemRepository.findFoodProductInPantry.mockResolvedValue(
-          null,
-        );
         mockShelfLifeService.inferStorageType.mockReturnValue('refrigerator');
         mockShelfLifeService.getDaysForStorageType.mockReturnValue(7);
       }
@@ -384,9 +380,6 @@ describe('PantryItemService', () => {
           foodGroup: 'Milk and milk products',
           shelfLifeId: SHELF_LIFE_ID,
         });
-        mockPantryItemRepository.findGenericFoodInPantry.mockResolvedValue(
-          null,
-        );
         mockPantryItemRepository.create.mockResolvedValue({
           ...mockPantryItem,
           expiryDate: null,
@@ -439,10 +432,6 @@ describe('PantryItemService', () => {
       const mockPantryItem = createMockPantryItemWithRelations();
       const mockItems = [mockPantryItem];
       mockPantryService.validatePantryExists.mockResolvedValue(pantryId);
-      mockFoodRepository.findById.mockResolvedValue({
-        id: TEST_IDS.FOOD,
-        name: 'Tomatoes',
-      });
       mockPantryItemRepository.findMany.mockResolvedValue(mockItems);
 
       const query = PantryItemsTestBuilder.createQueryPantryItemDto({
@@ -453,24 +442,27 @@ describe('PantryItemService', () => {
 
       expect(result.data).toHaveLength(1);
       expect(pantryService.validatePantryExists).toHaveBeenCalled();
-      expect(mockFoodRepository.findById).toHaveBeenCalled();
-      expect(repository.findMany).toHaveBeenCalled();
+      expect(mockFoodRepository.findById).not.toHaveBeenCalled();
+      expect(repository.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          pantryId,
+          foodProductId: TEST_IDS.FOOD,
+        }),
+      );
     });
 
-    it('should throw NotFoundException when foodProductId is provided but food does not exist', async () => {
+    it('should return empty data when filtering by foodProductId with no matching items', async () => {
       mockPantryService.validatePantryExists.mockResolvedValue(pantryId);
-      mockFoodRepository.findById.mockResolvedValue(null);
+      mockPantryItemRepository.findMany.mockResolvedValue([]);
 
       const query = PantryItemsTestBuilder.createQueryPantryItemDto({
         foodProductId: 'non-existent-food',
       });
+      const result = await service.findAll(query, userId);
 
-      await expect(service.findAll(query, userId)).rejects.toThrow(
-        NotFoundException,
-      );
+      expect(result.data).toHaveLength(0);
       expect(pantryService.validatePantryExists).toHaveBeenCalled();
-      expect(mockFoodRepository.findById).toHaveBeenCalled();
-      expect(repository.findMany).not.toHaveBeenCalled();
+      expect(repository.findMany).toHaveBeenCalled();
     });
 
     it('should return empty array when no items are found', async () => {
@@ -717,26 +709,27 @@ describe('PantryItemService', () => {
       );
     });
 
-    it('should throw ConflictException when food already exists in pantry', async () => {
+    it('should allow updating food reference to one already present in the pantry', async () => {
       const mockPantryItem = createMockPantryItemWithRelations();
+      const updatedItem = {
+        ...mockPantryItem,
+        foodProductId: 'food-2',
+      };
       mockPantryItemRepository.findById.mockResolvedValue(mockPantryItem);
       mockFoodRepository.findById.mockResolvedValue({
         id: 'food-2',
         name: 'Carrots',
       });
-      const prismaError = new PrismaClientKnownRequestError(
-        'Unique constraint failed',
-        {
-          code: ERROR_CODES.PRISMA_UNIQUE_CONSTRAINT,
-          clientVersion: '4.0.0',
-          meta: { target: ['pantryId', 'foodProductId'] },
-        },
-      );
-      mockPantryItemRepository.update.mockRejectedValue(prismaError);
+      mockPantryItemRepository.update.mockResolvedValue(updatedItem);
 
-      await expect(
-        service.update(itemId, { foodProductId: 'food-2' }, userId),
-      ).rejects.toThrow(ConflictException);
+      const result = await service.update(
+        itemId,
+        { foodProductId: 'food-2' },
+        userId,
+      );
+
+      expect(result.foodProductId).toBe('food-2');
+      expect(mockPantryItemRepository.update).toHaveBeenCalled();
     });
 
     it('should transform expiryDate string to Date object when updating', async () => {
@@ -879,7 +872,6 @@ describe('PantryItemService', () => {
       setupSuccessfulCreateMocks({
         mockPantryService,
         mockFoodRepository,
-        mockPantryItemRepository,
       });
       mockPantryItemRepository.create.mockResolvedValue({
         ...mockPantryItem,

--- a/src/pantry/services/pantry-items.service.spec.ts
+++ b/src/pantry/services/pantry-items.service.spec.ts
@@ -111,28 +111,47 @@ describe('PantryItemService', () => {
     });
 
     it('should allow creating a duplicate food product in the pantry', async () => {
+      const firstExpiryDate = new Date('2027-01-15');
+      const secondExpiryDate = new Date('2027-02-20');
       const createDto = PantryItemsTestBuilder.createCreatePantryItemDto({
-        expiryDate: new Date('2027-01-15'),
+        expiryDate: firstExpiryDate,
       });
-      const mockPantryItem = createMockPantryItemWithRelations();
+      const firstMockPantryItem = createMockPantryItemWithRelations();
+      const secondMockPantryItem = {
+        ...createMockPantryItemWithRelations(),
+        id: `${TEST_IDS.PANTRY_ITEM}-2`,
+        expiryDate: secondExpiryDate,
+      };
       setupSuccessfulCreateMocks({
         mockPantryService,
         mockFoodRepository,
       });
-      mockPantryItemRepository.create.mockResolvedValue(mockPantryItem);
+      mockPantryItemRepository.create
+        .mockResolvedValueOnce(firstMockPantryItem)
+        .mockResolvedValueOnce(secondMockPantryItem);
 
       const first = await service.create(createDto, userId);
       const second = await service.create(
         {
           ...createDto,
-          expiryDate: new Date('2027-02-20'),
+          expiryDate: secondExpiryDate,
         },
         userId,
       );
 
       expect(first.id).toBe(TEST_IDS.PANTRY_ITEM);
-      expect(second.id).toBe(TEST_IDS.PANTRY_ITEM);
+      expect(second.id).toBe(`${TEST_IDS.PANTRY_ITEM}-2`);
       expect(mockPantryItemRepository.create).toHaveBeenCalledTimes(2);
+      expect(mockPantryItemRepository.create).toHaveBeenNthCalledWith(
+        1,
+        expect.objectContaining({ expiryDate: firstExpiryDate }),
+        undefined,
+      );
+      expect(mockPantryItemRepository.create).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({ expiryDate: secondExpiryDate }),
+        undefined,
+      );
     });
 
     it('should throw BadRequestException when creation fails unexpectedly', async () => {

--- a/src/pantry/services/pantry-items.service.ts
+++ b/src/pantry/services/pantry-items.service.ts
@@ -1,6 +1,5 @@
 import {
   BadRequestException,
-  ConflictException,
   ForbiddenException,
   Injectable,
   Logger,
@@ -70,7 +69,6 @@ export class PantryItemService {
     } catch (err) {
       if (
         err instanceof NotFoundException ||
-        err instanceof ConflictException ||
         err instanceof ForbiddenException
       ) {
         throw err;
@@ -96,11 +94,9 @@ export class PantryItemService {
       const { foodProductId, genericFoodId } = createDto;
       this.validateFoodRefInput(foodProductId, genericFoodId);
 
-      const validatedEntity = await this.ensureUniqueAndExists(
-        resolvedPantryId,
+      const validatedEntity = await this.ensureFoodExists(
         foodProductId,
         genericFoodId,
-        tx,
       );
 
       const { foodName, shelfLifeId, categoryHints } = foodProductId
@@ -165,7 +161,6 @@ export class PantryItemService {
     } catch (err) {
       if (
         err instanceof NotFoundException ||
-        err instanceof ConflictException ||
         err instanceof ForbiddenException
       ) {
         throw err;
@@ -190,40 +185,15 @@ export class PantryItemService {
     }
   }
 
-  private async ensureUniqueAndExists(
-    pantryId: string,
+  private async ensureFoodExists(
     foodProductId?: string,
     genericFoodId?: string,
-    tx?: Prisma.TransactionClient,
   ) {
     if (foodProductId) {
-      const food = await this.validateFoodProductExists(foodProductId);
-      const existingItem =
-        await this.pantryItemRepository.findFoodProductInPantry(
-          pantryId,
-          foodProductId,
-          tx,
-        );
-      if (existingItem) {
-        throw new ConflictException(
-          'This food product is already in your pantry',
-        );
-      }
-      return food;
-    } else if (genericFoodId) {
-      const genericFood = await this.validateGenericFoodExists(genericFoodId);
-      const existingItem =
-        await this.pantryItemRepository.findGenericFoodInPantry(
-          pantryId,
-          genericFoodId,
-          tx,
-        );
-      if (existingItem) {
-        throw new ConflictException(
-          'This generic food is already in your pantry',
-        );
-      }
-      return genericFood;
+      return this.validateFoodProductExists(foodProductId);
+    }
+    if (genericFoodId) {
+      return this.validateGenericFoodExists(genericFoodId);
     }
 
     throw new Error('Either foodProductId or genericFoodId is required');
@@ -240,14 +210,8 @@ export class PantryItemService {
         userId,
         pantryId,
       );
-      // Only validate if either filter is provided
       if (foodProductId || genericFoodId) {
         this.validateFoodRefInput(foodProductId, genericFoodId);
-        await this.ensureUniqueAndExists(
-          resolvedPantryId,
-          foodProductId,
-          genericFoodId,
-        );
       }
       const filter: any = { pantryId: resolvedPantryId };
       if (foodProductId !== undefined) filter.foodProductId = foodProductId;
@@ -265,10 +229,7 @@ export class PantryItemService {
         }),
       };
     } catch (err) {
-      if (
-        err instanceof NotFoundException ||
-        err instanceof ConflictException
-      ) {
+      if (err instanceof NotFoundException) {
         throw err;
       }
       throw new BadRequestException(
@@ -352,8 +313,7 @@ export class PantryItemService {
           updateDto.foodProductId,
           updateDto.genericFoodId,
         );
-        await this.ensureUniqueAndExists(
-          item.pantryId,
+        await this.ensureFoodExists(
           updateDto.foodProductId,
           updateDto.genericFoodId,
         );
@@ -398,16 +358,12 @@ export class PantryItemService {
     } catch (err) {
       if (
         err instanceof NotFoundException ||
-        err instanceof ConflictException ||
         err instanceof ForbiddenException ||
         err instanceof BadRequestException
       ) {
         throw err;
       }
       const businessException = handlePrismaError(err, 'update', 'pantry_item');
-      if (businessException.name === 'ResourceAlreadyExistsException') {
-        throw new ConflictException('This pantry item already exists');
-      }
       handleServiceError(
         businessException,
         'Invalid pantry item update payload or value.',

--- a/src/pantry/test-utils/pantry-items-mocks.ts
+++ b/src/pantry/test-utils/pantry-items-mocks.ts
@@ -8,8 +8,6 @@ import {
 export function createMockPantryItemRepository() {
   return {
     create: jest.fn(),
-    findFoodProductInPantry: jest.fn(),
-    findGenericFoodInPantry: jest.fn(),
     findMany: jest.fn(),
     findById: jest.fn(),
     update: jest.fn(),
@@ -82,12 +80,13 @@ export function createMockPantryItemWithRelations() {
 export function setupSuccessfulCreateMocks({
   mockPantryService,
   mockFoodRepository,
-  mockPantryItemRepository,
+}: {
+  mockPantryService: ReturnType<typeof createMockPantryService>;
+  mockFoodRepository: ReturnType<typeof createMockFoodProductRepository>;
 }) {
   mockPantryService.validatePantryExists.mockResolvedValue(TEST_IDS.PANTRY);
   mockFoodRepository.findById.mockResolvedValue({
     id: TEST_IDS.FOOD,
     name: 'Tomatoes',
   });
-  mockPantryItemRepository.findFoodProductInPantry.mockResolvedValue(null);
 }

--- a/src/recipes/services/recommendations.service.spec.ts
+++ b/src/recipes/services/recommendations.service.spec.ts
@@ -114,4 +114,83 @@ describe('RecommendationsService', () => {
       'Organic Oat Milks',
     );
   });
+
+  it('picks the soonest-expiring duplicate as the match, keeping isExpiringSoon consistent', async () => {
+    mockPantryService.validatePantryExists.mockResolvedValue('pantry-1');
+    mockPantryItemRepository.findMany.mockResolvedValue([
+      {
+        id: 'pantry-item-soon',
+        pantryId: 'pantry-1',
+        foodProductId: 'food-1',
+        genericFoodId: null,
+        expiryDate: new Date(Date.now() + 2 * 24 * 60 * 60 * 1000),
+        foodProduct: { name: 'Tomatoes' },
+        genericFood: null,
+      },
+      {
+        id: 'pantry-item-far-future',
+        pantryId: 'pantry-1',
+        foodProductId: 'food-1',
+        genericFoodId: null,
+        expiryDate: new Date(Date.now() + 60 * 24 * 60 * 60 * 1000),
+        foodProduct: { name: 'Tomatoes' },
+        genericFood: null,
+      },
+    ]);
+    mockRecipesRepository.findCandidatesForRecommendation.mockResolvedValue([
+      {
+        id: 'recipe-1',
+        userId: 'user-1',
+        title: 'Tomato Soup',
+        description: null,
+        instructions: null,
+        prepTime: null,
+        cookTime: null,
+        servings: null,
+        difficulty: null,
+        tags: [],
+        nutritionalInfo: null,
+        sustainabilityScore: null,
+        price: null,
+        allergens: [],
+        rating: 0,
+        ratingCount: 0,
+        externalId: null,
+        imageUrl: null,
+        videoUrl: null,
+        cuisineType: null,
+        category: null,
+        isPublic: true,
+        dietaryLabels: [],
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        ingredients: [
+          {
+            id: 'ing-1',
+            recipeId: 'recipe-1',
+            name: 'Tomatoes',
+            measure: '2 pcs',
+            order: 0,
+            createdAt: new Date(),
+            updatedAt: new Date(),
+            itemType: 'food_product',
+            foodProductId: 'food-1',
+            genericFoodId: null,
+            foodProduct: null,
+            genericFood: null,
+          },
+        ],
+      },
+    ]);
+
+    const result = await service.getRecommendations('user-1', {
+      expiringWithinDays: 7,
+      limit: 10,
+      offset: 0,
+    });
+
+    const match = result.data[0].matchedIngredients[0];
+    expect(match.isExpiringSoon).toBe(true);
+    expect(match.daysUntilExpiry).toBeLessThanOrEqual(7);
+  });
 });

--- a/src/recipes/services/recommendations.service.ts
+++ b/src/recipes/services/recommendations.service.ts
@@ -226,20 +226,34 @@ export class RecommendationsService {
     expiringFoodIds: Set<string>,
     expiringCategoryIds: Set<string>,
   ): RecipeRecommendationScore[] {
-    // Build lookup maps for pantry item names
+    // Build lookup maps for pantry item names. When multiple pantry items
+    // share the same food/category/name (duplicates are allowed), always
+    // keep the soonest-expiring one so this representative stays consistent
+    // with the expiringFoodIds/expiringCategoryIds sets below.
     const pantryItemByFoodId = new Map<string, PantryItemWithRelations>();
     const pantryItemByCategoryId = new Map<string, PantryItemWithRelations>();
     const pantryItemByNormalizedName = new Map<
       string,
       PantryItemWithRelations
     >();
+    const upsertMostUrgent = (
+      map: Map<string, PantryItemWithRelations>,
+      key: string,
+      item: PantryItemWithRelations,
+    ) => {
+      const existing = map.get(key);
+      if (!existing || this.isMoreUrgent(item, existing)) {
+        map.set(key, item);
+      }
+    };
     for (const item of pantryItems) {
-      if (item.foodProductId) pantryItemByFoodId.set(item.foodProductId, item);
+      if (item.foodProductId)
+        upsertMostUrgent(pantryItemByFoodId, item.foodProductId, item);
       if (item.genericFoodId)
-        pantryItemByCategoryId.set(item.genericFoodId, item);
+        upsertMostUrgent(pantryItemByCategoryId, item.genericFoodId, item);
       const normalizedName = this.normalizeText(this.getPantryItemName(item));
       if (normalizedName) {
-        pantryItemByNormalizedName.set(normalizedName, item);
+        upsertMostUrgent(pantryItemByNormalizedName, normalizedName, item);
       }
     }
 
@@ -309,6 +323,36 @@ export class RecommendationsService {
         expiringMatchCount,
       };
     });
+  }
+
+  /**
+   * True if `candidate` should be preferred over `current` as the
+   * representative pantry item for a shared food/category/name key.
+   * Preference: soonest upcoming expiry > most recent past expiry > no expiry.
+   */
+  private isMoreUrgent(
+    candidate: PantryItemWithRelations,
+    current: PantryItemWithRelations,
+  ): boolean {
+    const now = Date.now();
+    const candidateTime = candidate.expiryDate
+      ? new Date(candidate.expiryDate).getTime()
+      : null;
+    const currentTime = current.expiryDate
+      ? new Date(current.expiryDate).getTime()
+      : null;
+
+    const candidateUpcoming = candidateTime !== null && candidateTime >= now;
+    const currentUpcoming = currentTime !== null && currentTime >= now;
+
+    if (candidateUpcoming || currentUpcoming) {
+      if (candidateUpcoming !== currentUpcoming) return candidateUpcoming;
+      return candidateTime! < currentTime!;
+    }
+    if (candidateTime !== null && currentTime !== null) {
+      return candidateTime > currentTime;
+    }
+    return candidateTime !== null && currentTime === null;
   }
 
   private normalizeText(value?: string | null): string {

--- a/test/e2e/pantry-items.e2e-spec.ts
+++ b/test/e2e/pantry-items.e2e-spec.ts
@@ -92,4 +92,47 @@ describe('Pantry Items Auto Expiry', () => {
     expect(pantryItem.expiryDate).toBeNull();
     expect(pantryItem.expiryDateSource).toBeNull();
   });
+
+  it('should allow duplicate products with different expiry dates', async () => {
+    const expiryA = new Date('2027-01-15');
+    const expiryB = new Date('2027-03-01');
+
+    const first = await prisma.pantryItem.create({
+      data: {
+        pantryId: fixtures.pantryId,
+        foodProductId: fixtures.foodProductId,
+        quantity: 1,
+        unit: 'PIECES',
+        expiryDate: expiryA,
+        expiryDateSource: 'manual',
+      },
+    });
+
+    const second = await prisma.pantryItem.create({
+      data: {
+        pantryId: fixtures.pantryId,
+        foodProductId: fixtures.foodProductId,
+        quantity: 2,
+        unit: 'PIECES',
+        expiryDate: expiryB,
+        expiryDateSource: 'manual',
+      },
+    });
+
+    const items = await prisma.pantryItem.findMany({
+      where: {
+        pantryId: fixtures.pantryId,
+        foodProductId: fixtures.foodProductId,
+      },
+      orderBy: { expiryDate: 'asc' },
+    });
+
+    expect(first.id).not.toBe(second.id);
+    expect(items).toHaveLength(2);
+    expect(items.map((i) => i.id)).toEqual(
+      expect.arrayContaining([first.id, second.id]),
+    );
+    expect(items[0].expiryDate).toEqual(expiryA);
+    expect(items[1].expiryDate).toEqual(expiryB);
+  });
 });


### PR DESCRIPTION
# Pull Request

## Description

Allow the same food product (or generic food) to appear multiple times in a pantry, e.g. separate lots with different expiration dates. Each pantry line is identified by its own `itemId`; uniqueness is no longer enforced per food per pantry.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Type of Changes

- [x] Database changes
- [x] Schema changes (migration included)
- [x] API changes

## Changes Made

- Dropped `@@unique([pantryId, foodProductId])` and `@@unique([pantryId, genericFoodId])` on `PantryItem` (migration `20260726200000_allow_duplicate_pantry_items`)
- Replaced `ensureUniqueAndExists` with `ensureFoodExists` (catalog validation only; no 409 on duplicate food)
- Fixed `findAll` so filtering by food no longer throws conflict when the item exists
- Removed unused `findFoodProductInPantry` / `findGenericFoodInPantry` helpers
- Updated unit tests; added e2e coverage for duplicate products with different expiry dates

## Testing

- [x] White box testing
- [x] Black box testing

- Unit: `pantry-items.service.spec.ts`, `pantry-items.repository.spec.ts`
- E2E: `pantry-items.e2e-spec.ts` (two rows, same `foodProductId`, different `expiryDate`)

## Deployment Notes

- [x] Database migration required

```bash
npx prisma migrate deploy

---

## 🐳 Docker Image Preview

**Available tags:**
- `ghcr.io/reedu-reengineering-education/foodmission-data-framework:pr-264`
- `ghcr.io/reedu-reengineering-education/foodmission-data-framework:sha-6f0a7f6`

**Pull and test:**
```bash
docker pull ghcr.io/reedu-reengineering-education/foodmission-data-framework:pr-264
docker run -p 3000:3000 ghcr.io/reedu-reengineering-education/foodmission-data-framework:pr-264
```

**Multi-arch support:** ✅ AMD64 & ARM64
