### PR TITLE
fix: add scripts to prod container image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -59,6 +59,8 @@ COPY --from=builder --chown=nestjs:nodejs /workspace/dist ./dist
 COPY --from=builder --chown=nestjs:nodejs /workspace/node_modules ./node_modules
 COPY --from=builder --chown=nestjs:nodejs /workspace/prisma ./prisma
 COPY --from=builder --chown=nestjs:nodejs /workspace/prisma.config.ts ./prisma.config.ts
+COPY --from=builder --chown=nestjs:nodejs /workspace/scripts ./scripts
+COPY --from=builder --chown=nestjs:nodejs /workspace/tsconfig.json ./tsconfig.json
 
 # Switch to non-root user
 USER nestjs


### PR DESCRIPTION
# Pull Request

## Description

add scripts to prod container image



---

## 🐳 Docker Image Preview

**Available tags:**
- `ghcr.io/reedu-reengineering-education/foodmission-data-framework:pr-265`
- `ghcr.io/reedu-reengineering-education/foodmission-data-framework:sha-f645e21`

**Pull and test:**
```bash
docker pull ghcr.io/reedu-reengineering-education/foodmission-data-framework:pr-265
docker run -p 3000:3000 ghcr.io/reedu-reengineering-education/foodmission-data-framework:pr-265
```

**Multi-arch support:** ✅ AMD64 & ARM64
