### PR TITLE
feat: add endpoint for app to emit usaage events

### DIFF
--- a/docs/event-emission-guide.md
+++ b/docs/event-emission-guide.md
@@ -44,7 +44,7 @@ flowchart TD
    Do not insert into `user_events` from controllers (except the allowlisted client path above), seeds (except explicit seed tooling with `EventSource.SEED`), or the UI.
 
 3. **Use idempotency for retries and rewards**  
-   Stable keys, e.g. `onboarding-completed:{userId}`, `meal-logged:{userId}:{mealId}`, `mission-completed:{userId}:{missionId}`, `app-session-opened:{userId}:{sessionId}`. Concurrent retries should return the existing row (`replayed: true`), not a duplicate fact.
+   Stable keys, e.g. `onboarding-completed:{userId}`, `meal-logged:{userId}:{mealId}`, `mission-completed:{userId}:{missionId}`. For `POST /events`, the server builds `{eventType}:{userId}:{sessionId}` from the authenticated user and required `metadata.sessionId` — clients do not supply `idempotencyKey`. Concurrent retries should return the existing row (`replayed: true`), not a duplicate fact.
 
 4. **Keep domains separate** (see catalog)  
    - **Account** — `USER_LOGGED_IN`, `ONBOARDING_COMPLETED`, `USER_GROUP_JOINED` / `USER_GROUP_LEFT`  

--- a/docs/event-emission-guide.md
+++ b/docs/event-emission-guide.md
@@ -14,7 +14,7 @@ Catalog domains: **Account**, **App**, **Wallet**, **Progress**, **Achievements*
 
 The only writer is [`UserEventService.record()`](../src/events/services/user-event.service.ts). Feature modules import `EventsModule` and call `record` as a side effect of domain work.
 
-A limited authenticated API — `POST /api/v1/events` — may record **allowlisted** client types only (`CLIENT_RECORDABLE_EVENT_TYPES`: currently `APP_SESSION_OPENED`, `APP_SESSION_ENDED`). All other types stay server-derived.
+A limited authenticated API — `POST /api/v1/events` (`EventsApiModule`) — may record **allowlisted** client types only (`CLIENT_RECORDABLE_EVENT_TYPES`: currently `APP_SESSION_OPENED`, `APP_SESSION_ENDED`). All other types stay server-derived. The shared `EventsModule` exports only `UserEventService` (no HTTP controller) so Auth/Gamification can import it without mounting routes.
 
 ```mermaid
 flowchart TD

--- a/docs/event-emission-guide.md
+++ b/docs/event-emission-guide.md
@@ -12,19 +12,25 @@ Catalog domains: **Account**, **App**, **Wallet**, **Progress**, **Achievements*
 
 ## How emission works today
 
-There is **no public “post an event” API**. The only writer is [`UserEventService.record()`](../src/events/services/user-event.service.ts). Feature modules import `EventsModule` and call `record` as a side effect of domain work.
+The only writer is [`UserEventService.record()`](../src/events/services/user-event.service.ts). Feature modules import `EventsModule` and call `record` as a side effect of domain work.
+
+A limited authenticated API — `POST /api/v1/events` — may record **allowlisted** client types only (`CLIENT_RECORDABLE_EVENT_TYPES`: currently `APP_SESSION_OPENED`, `APP_SESSION_ENDED`). All other types stay server-derived.
 
 ```mermaid
 flowchart TD
   client[Client / UI]
   domainAPI[Domain HTTP API]
+  eventsAPI["POST /events allowlisted"]
   domainSvc[Domain service]
+  clientSvc[ClientEventService]
   eventSvc[UserEventService.record]
   wallet[GamificationWalletService.award]
   db[(user_events)]
 
   client --> domainAPI --> domainSvc
+  client --> eventsAPI --> clientSvc
   domainSvc -->|"side effect in same tx"| eventSvc --> db
+  clientSvc --> eventSvc
   domainSvc -->|"optional reward"| wallet
   wallet -->|"creates or links event"| eventSvc
 ```
@@ -32,27 +38,27 @@ flowchart TD
 ## Best practices
 
 1. **Emit as a side effect of a domain write**  
-   Prefer deriving the event from a validated mutation (meal saved, progress completed), not from a client-supplied event name.
+   Prefer deriving the event from a validated mutation (meal saved, progress completed), not from a client-supplied event name — except allowlisted app-session types via `POST /events`.
 
 2. **One writer: `UserEventService.record`**  
-   Do not insert into `user_events` from controllers, seeds (except explicit seed tooling with `EventSource.SEED`), or the UI.
+   Do not insert into `user_events` from controllers (except the allowlisted client path above), seeds (except explicit seed tooling with `EventSource.SEED`), or the UI.
 
 3. **Use idempotency for retries and rewards**  
-   Stable keys, e.g. `onboarding-completed:{userId}`, `meal-logged:{userId}:{mealId}`, `mission-completed:{userId}:{missionId}`. Concurrent retries should return the existing row (`replayed: true`), not a duplicate fact.
+   Stable keys, e.g. `onboarding-completed:{userId}`, `meal-logged:{userId}:{mealId}`, `mission-completed:{userId}:{missionId}`, `app-session-opened:{userId}:{sessionId}`. Concurrent retries should return the existing row (`replayed: true`), not a duplicate fact.
 
 4. **Keep domains separate** (see catalog)  
    - **Account** — `USER_LOGGED_IN`, `ONBOARDING_COMPLETED`, `USER_GROUP_JOINED` / `USER_GROUP_LEFT`  
-   - **App** — `APP_OPENED` (prefer server-side / authenticated heartbeat with day-level idempotency if used for streaks)  
+   - **App** — `APP_SESSION_OPENED` / `APP_SESSION_ENDED` (client-allowlisted via `POST /events`)  
    - **Behavioural** — evidence (`MEAL_*`, `SWAP_*`, `LEARNING_*`, …)  
    - **Progress** — `MISSION_STARTED` / `MISSION_COMPLETED`, `CHALLENGE_STARTED` / `CHALLENGE_COMPLETED`, `QUEST_*`  
    - **Achievements** — `BADGE_EARNED`, `PROGRESS_INDICATOR_UPDATED`  
    - **Wallet** — `WALLET_POINTS_AWARDED` / `WALLET_XP_AWARDED` / `WALLET_MANUAL_ADJUSTMENT`; link with `eventId` when a behavioural/progress event already exists
 
 5. **`source` = observing feature, not the consumer**  
-   Meal log → `EventSource.MEAL_LOG` even if a mission later counts it. Mission completion → `EventSource.MISSION`.
+   Meal log → `EventSource.MEAL_LOG` even if a mission later counts it. Mission completion → `EventSource.MISSION`. Client session events → `EventSource.APP`.
 
 6. **Do not trust the client for trust-sensitive types**  
-   Anything that advances missions, awards points, or proves diet/sustainability claims must be server-derived or server-validated.
+   Anything that advances missions, awards points, or proves diet/sustainability claims must be server-derived or server-validated. Session open/end are allowlisted; duration in metadata is informational only unless you add server validation later.
 
 7. **Metadata is context, not the event kind**  
    Put ids, amounts, tags in `metadata`; put *what happened* in `eventType`. Prefer `subject: { type, id }` via `EventSubjectType` (merged into `metadata.subject`).

--- a/src/app/engagement.module.ts
+++ b/src/app/engagement.module.ts
@@ -1,5 +1,6 @@
 import { Module } from '@nestjs/common';
 import { ChallengesModule } from '../challenges/challenges.module';
+import { EventsApiModule } from '../events/events-api.module';
 import { KnowledgeModule } from '../knowledge/knowledge.module';
 import { MissionsModule } from '../missions/missions.module';
 import { SurveysModule } from '../surveys/surveys.module';
@@ -7,6 +8,7 @@ import { GamificationModule } from '../gamification/gamification.module';
 
 @Module({
   imports: [
+    EventsApiModule,
     ChallengesModule,
     MissionsModule,
     KnowledgeModule,

--- a/src/events/controllers/events.controller.spec.ts
+++ b/src/events/controllers/events.controller.spec.ts
@@ -30,10 +30,10 @@ describe('EventsController', () => {
   });
 
   it('delegates to ClientEventService and returns the event DTO', async () => {
+    const sessionId = '550e8400-e29b-41d4-a716-446655440000';
     const dto: CreateClientEventDto = {
       eventType: EventType.APP_SESSION_OPENED,
-      metadata: { sessionId: 's1', platform: 'ios' },
-      idempotencyKey: 'app-session-opened:u1:s1',
+      metadata: { sessionId, platform: 'ios' },
     };
     const eventDto = {
       id: 'evt-1',
@@ -41,7 +41,7 @@ describe('EventsController', () => {
       eventType: EventType.APP_SESSION_OPENED,
       source: 'app',
       timestamp: new Date(),
-      metadata: { sessionId: 's1', platform: 'ios' },
+      metadata: { sessionId, platform: 'ios' },
       groupId: null,
     };
     clientEventService.record.mockResolvedValue({
@@ -55,7 +55,6 @@ describe('EventsController', () => {
       userId: 'u1',
       eventType: dto.eventType,
       metadata: dto.metadata,
-      idempotencyKey: dto.idempotencyKey,
     });
     expect(result).toBe(eventDto);
   });

--- a/src/events/controllers/events.controller.spec.ts
+++ b/src/events/controllers/events.controller.spec.ts
@@ -1,0 +1,62 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ThrottlerGuard } from '@nestjs/throttler';
+import { DataBaseAuthGuard } from '../../common/guards/database-auth.guards';
+import { EventType } from '../event-types';
+import { CreateClientEventDto } from '../dto/create-client-event.dto';
+import { ClientEventService } from '../services/client-event.service';
+import { EventsController } from './events.controller';
+
+describe('EventsController', () => {
+  let controller: EventsController;
+  const clientEventService = {
+    record: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [EventsController],
+      providers: [
+        { provide: ClientEventService, useValue: clientEventService },
+      ],
+    })
+      .overrideGuard(ThrottlerGuard)
+      .useValue({ canActivate: () => true })
+      .overrideGuard(DataBaseAuthGuard)
+      .useValue({ canActivate: () => true })
+      .compile();
+
+    controller = module.get(EventsController);
+    jest.clearAllMocks();
+  });
+
+  it('delegates to ClientEventService and returns the event DTO', async () => {
+    const dto: CreateClientEventDto = {
+      eventType: EventType.APP_SESSION_OPENED,
+      metadata: { sessionId: 's1', platform: 'ios' },
+      idempotencyKey: 'app-session-opened:u1:s1',
+    };
+    const eventDto = {
+      id: 'evt-1',
+      userId: 'u1',
+      eventType: EventType.APP_SESSION_OPENED,
+      source: 'app',
+      timestamp: new Date(),
+      metadata: { sessionId: 's1', platform: 'ios' },
+      groupId: null,
+    };
+    clientEventService.record.mockResolvedValue({
+      event: eventDto,
+      replayed: false,
+    });
+
+    const result = await controller.create('u1', dto);
+
+    expect(clientEventService.record).toHaveBeenCalledWith({
+      userId: 'u1',
+      eventType: dto.eventType,
+      metadata: dto.metadata,
+      idempotencyKey: dto.idempotencyKey,
+    });
+    expect(result).toBe(eventDto);
+  });
+});

--- a/src/events/controllers/events.controller.ts
+++ b/src/events/controllers/events.controller.ts
@@ -1,0 +1,58 @@
+import { Body, Controller, HttpCode, HttpStatus, Post, UseGuards } from '@nestjs/common';
+import {
+  ApiBearerAuth,
+  ApiBody,
+  ApiOperation,
+  ApiResponse,
+  ApiTags,
+} from '@nestjs/swagger';
+import { Throttle, ThrottlerGuard } from '@nestjs/throttler';
+import { Roles } from 'nest-keycloak-connect';
+import { ApiCrudErrorResponses } from '../../common/decorators/api-error-responses.decorator';
+import { CurrentUser } from '../../common/decorators/current-user.decorator';
+import { DataBaseAuthGuard } from '../../common/guards/database-auth.guards';
+import { CreateClientEventDto } from '../dto/create-client-event.dto';
+import { UserEventDto } from '../dto/user-event.dto';
+import { ClientEventService } from '../services/client-event.service';
+
+@ApiTags('events')
+@Controller('events')
+@UseGuards(ThrottlerGuard, DataBaseAuthGuard)
+export class EventsController {
+  constructor(private readonly clientEventService: ClientEventService) {}
+
+  @Post()
+  @HttpCode(HttpStatus.OK)
+  @Roles('user', 'admin')
+  @ApiBearerAuth('JWT-auth')
+  @Throttle({
+    short: { limit: 2, ttl: 1_000 },
+    medium: { limit: 30, ttl: 60_000 },
+    long: { limit: 200, ttl: 900_000 },
+  })
+  @ApiOperation({
+    summary: 'Record a client-allowlisted user event',
+    description:
+      'Accepts APP_SESSION_OPENED / APP_SESSION_ENDED only. ' +
+      'Other event types must be derived server-side from domain mutations.',
+  })
+  @ApiBody({ type: CreateClientEventDto })
+  @ApiResponse({
+    status: 200,
+    description: 'Event recorded (or replayed via idempotency key)',
+    type: UserEventDto,
+  })
+  @ApiCrudErrorResponses()
+  async create(
+    @CurrentUser('id') userId: string,
+    @Body() dto: CreateClientEventDto,
+  ): Promise<UserEventDto> {
+    const { event } = await this.clientEventService.record({
+      userId,
+      eventType: dto.eventType,
+      metadata: dto.metadata,
+      idempotencyKey: dto.idempotencyKey,
+    });
+    return event;
+  }
+}

--- a/src/events/controllers/events.controller.ts
+++ b/src/events/controllers/events.controller.ts
@@ -34,7 +34,9 @@ export class EventsController {
     summary: 'Record a client-allowlisted user event',
     description:
       'Accepts APP_SESSION_OPENED / APP_SESSION_ENDED only. ' +
-      'Other event types must be derived server-side from domain mutations.',
+      'Requires metadata.sessionId; idempotency key is built server-side as ' +
+      '{eventType}:{userId}:{sessionId}. Other event types must be derived ' +
+      'server-side from domain mutations.',
   })
   @ApiBody({ type: CreateClientEventDto })
   @ApiResponse({
@@ -51,7 +53,6 @@ export class EventsController {
       userId,
       eventType: dto.eventType,
       metadata: dto.metadata,
-      idempotencyKey: dto.idempotencyKey,
     });
     return event;
   }

--- a/src/events/controllers/events.controller.ts
+++ b/src/events/controllers/events.controller.ts
@@ -1,4 +1,11 @@
-import { Body, Controller, HttpCode, HttpStatus, Post, UseGuards } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  HttpCode,
+  HttpStatus,
+  Post,
+  UseGuards,
+} from '@nestjs/common';
 import {
   ApiBearerAuth,
   ApiBody,

--- a/src/events/dto/create-client-event.dto.ts
+++ b/src/events/dto/create-client-event.dto.ts
@@ -1,15 +1,61 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
 import {
   IsIn,
+  IsInt,
   IsObject,
   IsOptional,
   IsString,
+  IsUUID,
   MaxLength,
+  Min,
+  ValidateNested,
 } from 'class-validator';
 import {
   CLIENT_RECORDABLE_EVENT_TYPES,
   ClientRecordableEventType,
 } from '../event-types';
+
+/** Context for client-allowlisted app session events. */
+export class ClientEventMetadataDto {
+  @ApiProperty({
+    description: 'Client-generated session id (required for idempotency)',
+    format: 'uuid',
+    example: '550e8400-e29b-41d4-a716-446655440000',
+  })
+  @IsUUID()
+  sessionId!: string;
+
+  @ApiPropertyOptional({
+    description: 'Client platform (e.g. ios, android, web)',
+    example: 'ios',
+    maxLength: 64,
+  })
+  @IsOptional()
+  @IsString()
+  @MaxLength(64)
+  platform?: string;
+
+  @ApiPropertyOptional({
+    description: 'Client app version',
+    example: '1.2.3',
+    maxLength: 64,
+  })
+  @IsOptional()
+  @IsString()
+  @MaxLength(64)
+  appVersion?: string;
+
+  @ApiPropertyOptional({
+    description:
+      'Foreground duration in seconds (informational; not server-validated)',
+    example: 420,
+  })
+  @IsOptional()
+  @IsInt()
+  @Min(0)
+  durationSeconds?: number;
+}
 
 export class CreateClientEventDto {
   @ApiProperty({
@@ -20,27 +66,13 @@ export class CreateClientEventDto {
   @IsIn([...CLIENT_RECORDABLE_EVENT_TYPES])
   eventType!: ClientRecordableEventType;
 
-  @ApiPropertyOptional({
+  @ApiProperty({
     description:
-      'Event context (e.g. sessionId, platform, appVersion, durationSeconds). ' +
-      'Do not encode the event kind here.',
-    type: 'object',
-    additionalProperties: true,
-    example: { sessionId: '550e8400-e29b-41d4-a716-446655440000', platform: 'ios' },
+      'Event context. sessionId is required; the server builds the idempotency key.',
+    type: ClientEventMetadataDto,
   })
-  @IsOptional()
   @IsObject()
-  metadata?: Record<string, unknown>;
-
-  @ApiPropertyOptional({
-    description:
-      'Stable unique key so retries do not double-write. ' +
-      'Suggested: app-session-opened:{userId}:{sessionId}',
-    example: 'app-session-opened:user-id:session-id',
-    maxLength: 255,
-  })
-  @IsOptional()
-  @IsString()
-  @MaxLength(255)
-  idempotencyKey?: string;
+  @ValidateNested()
+  @Type(() => ClientEventMetadataDto)
+  metadata!: ClientEventMetadataDto;
 }

--- a/src/events/dto/create-client-event.dto.ts
+++ b/src/events/dto/create-client-event.dto.ts
@@ -1,0 +1,46 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import {
+  IsIn,
+  IsObject,
+  IsOptional,
+  IsString,
+  MaxLength,
+} from 'class-validator';
+import {
+  CLIENT_RECORDABLE_EVENT_TYPES,
+  ClientRecordableEventType,
+} from '../event-types';
+
+export class CreateClientEventDto {
+  @ApiProperty({
+    description: 'Allowlisted client event type',
+    enum: CLIENT_RECORDABLE_EVENT_TYPES,
+    example: 'APP_SESSION_OPENED',
+  })
+  @IsIn([...CLIENT_RECORDABLE_EVENT_TYPES])
+  eventType!: ClientRecordableEventType;
+
+  @ApiPropertyOptional({
+    description:
+      'Event context (e.g. sessionId, platform, appVersion, durationSeconds). ' +
+      'Do not encode the event kind here.',
+    type: 'object',
+    additionalProperties: true,
+    example: { sessionId: '550e8400-e29b-41d4-a716-446655440000', platform: 'ios' },
+  })
+  @IsOptional()
+  @IsObject()
+  metadata?: Record<string, unknown>;
+
+  @ApiPropertyOptional({
+    description:
+      'Stable unique key so retries do not double-write. ' +
+      'Suggested: app-session-opened:{userId}:{sessionId}',
+    example: 'app-session-opened:user-id:session-id',
+    maxLength: 255,
+  })
+  @IsOptional()
+  @IsString()
+  @MaxLength(255)
+  idempotencyKey?: string;
+}

--- a/src/events/event-types.ts
+++ b/src/events/event-types.ts
@@ -30,10 +30,10 @@
  * - **Learning** — `{ contentId?, contentType? }`
  * - **Wallet** — `{ currency, amount, reason }`
  * - **Onboarding** — `{ segment }`
- * - **App session** — `{ sessionId?, platform?, appVersion?, durationSeconds? }`.
- *   Client-submittable via `POST /events` (allowlisted). Prefer idempotency
- *   `app-session-opened:{userId}:{sessionId}` / `app-session-ended:{userId}:{sessionId}`.
- *   Subject is usually `USER`.
+ * - **App session** — `{ sessionId, platform?, appVersion?, durationSeconds? }`.
+ *   Client-submittable via `POST /events` (allowlisted). `sessionId` is required;
+ *   the server builds idempotency `{eventType}:{userId}:{sessionId}` (do not use
+ *   timestamps — retries must reuse a stable key). Subject is usually `USER`.
  * - **Group membership** — `{ groupId }` (+ `groupId` column when scoped)
  * - **Mission / challenge link** — optional `{ missionId? }` / `{ challengeId? }`
  *   on behavioural events; emit `MISSION_STARTED` / `MISSION_COMPLETED` and

--- a/src/events/event-types.ts
+++ b/src/events/event-types.ts
@@ -3,7 +3,7 @@
  *
  * ## Domains
  * - **Account** — session / onboarding / groups (`USER_LOGGED_IN`, `ONBOARDING_COMPLETED`, `USER_GROUP_*`)
- * - **App** — session-level app facts (`APP_OPENED`)
+ * - **App** — session-level app facts (`APP_SESSION_OPENED`, `APP_SESSION_ENDED`)
  * - **Wallet** — points / XP / admin adjustments (`WALLET_*`)
  * - **Progress** — mission / challenge / quest completion
  * - **Achievements** — badges and progress indicators
@@ -30,9 +30,10 @@
  * - **Learning** — `{ contentId?, contentType? }`
  * - **Wallet** — `{ currency, amount, reason }`
  * - **Onboarding** — `{ segment }`
- * - **App open** — optional `{ platform?, appVersion? }`; prefer day-level idempotency
- *   (`app-opened:{userId}:{YYYY-MM-DD}`) if used for streaks / active days.
- *   Subject is usually `USER`; use `APP` when the subject is the client app/platform itself.
+ * - **App session** — `{ sessionId?, platform?, appVersion?, durationSeconds? }`.
+ *   Client-submittable via `POST /events` (allowlisted). Prefer idempotency
+ *   `app-session-opened:{userId}:{sessionId}` / `app-session-ended:{userId}:{sessionId}`.
+ *   Subject is usually `USER`.
  * - **Group membership** — `{ groupId }` (+ `groupId` column when scoped)
  * - **Mission / challenge link** — optional `{ missionId? }` / `{ challengeId? }`
  *   on behavioural events; emit `MISSION_STARTED` / `MISSION_COMPLETED` and
@@ -56,7 +57,8 @@ export const EventType = {
   // ==========================================
   // APP
   // ==========================================
-  APP_OPENED: 'APP_OPENED',
+  APP_SESSION_OPENED: 'APP_SESSION_OPENED',
+  APP_SESSION_ENDED: 'APP_SESSION_ENDED',
 
   // ==========================================
   // WALLET
@@ -171,6 +173,18 @@ export const EventType = {
 } as const;
 
 export type EventTypeValue = (typeof EventType)[keyof typeof EventType];
+
+/**
+ * Event types the authenticated client may POST to `/events`.
+ * Trust-sensitive types (wallet, behavioural evidence, progress) stay server-only.
+ */
+export const CLIENT_RECORDABLE_EVENT_TYPES = [
+  EventType.APP_SESSION_OPENED,
+  EventType.APP_SESSION_ENDED,
+] as const;
+
+export type ClientRecordableEventType =
+  (typeof CLIENT_RECORDABLE_EVENT_TYPES)[number];
 
 /**
  * Who produced the event (service / channel).

--- a/src/events/events-api.module.ts
+++ b/src/events/events-api.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { EventsController } from './controllers/events.controller';
+import { EventsModule } from './events.module';
+import { ClientEventService } from './services/client-event.service';
+
+/** Authenticated client event HTTP API (`POST /events`). */
+@Module({
+  imports: [EventsModule],
+  controllers: [EventsController],
+  providers: [ClientEventService],
+})
+export class EventsApiModule {}

--- a/src/events/events-api.module.ts
+++ b/src/events/events-api.module.ts
@@ -1,12 +1,15 @@
 import { Module } from '@nestjs/common';
+import { CommonModule } from '../common/common.module';
+import { DatabaseModule } from '../database/database.module';
+import { UsersRepository } from '../users/repositories/users.repository';
 import { EventsController } from './controllers/events.controller';
 import { EventsModule } from './events.module';
 import { ClientEventService } from './services/client-event.service';
 
 /** Authenticated client event HTTP API (`POST /events`). */
 @Module({
-  imports: [EventsModule],
+  imports: [DatabaseModule, CommonModule, EventsModule],
   controllers: [EventsController],
-  providers: [ClientEventService],
+  providers: [ClientEventService, UsersRepository],
 })
 export class EventsApiModule {}

--- a/src/events/events.module.ts
+++ b/src/events/events.module.ts
@@ -1,10 +1,13 @@
 import { Module } from '@nestjs/common';
 import { DatabaseModule } from '../database/database.module';
+import { EventsController } from './controllers/events.controller';
+import { ClientEventService } from './services/client-event.service';
 import { UserEventService } from './services/user-event.service';
 
 @Module({
   imports: [DatabaseModule],
-  providers: [UserEventService],
+  controllers: [EventsController],
+  providers: [UserEventService, ClientEventService],
   exports: [UserEventService],
 })
 export class EventsModule {}

--- a/src/events/events.module.ts
+++ b/src/events/events.module.ts
@@ -1,13 +1,14 @@
 import { Module } from '@nestjs/common';
 import { DatabaseModule } from '../database/database.module';
-import { EventsController } from './controllers/events.controller';
-import { ClientEventService } from './services/client-event.service';
 import { UserEventService } from './services/user-event.service';
 
+/**
+ * Shared ledger writer only — safe to import from Auth/Gamification without
+ * mounting HTTP controllers (avoids pulling ThrottlerGuard into lean e2e apps).
+ */
 @Module({
   imports: [DatabaseModule],
-  controllers: [EventsController],
-  providers: [UserEventService, ClientEventService],
+  providers: [UserEventService],
   exports: [UserEventService],
 })
 export class EventsModule {}

--- a/src/events/services/client-event.service.spec.ts
+++ b/src/events/services/client-event.service.spec.ts
@@ -1,6 +1,9 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { EventSource, EventType } from '../event-types';
-import { ClientEventService } from './client-event.service';
+import {
+  buildClientEventIdempotencyKey,
+  ClientEventService,
+} from './client-event.service';
 import { UserEventService } from './user-event.service';
 
 describe('ClientEventService', () => {
@@ -21,7 +24,20 @@ describe('ClientEventService', () => {
     jest.clearAllMocks();
   });
 
+  it('builds a user-scoped idempotency key from eventType + userId + sessionId', () => {
+    expect(
+      buildClientEventIdempotencyKey(
+        EventType.APP_SESSION_OPENED,
+        'u1',
+        '550e8400-e29b-41d4-a716-446655440000',
+      ),
+    ).toBe(
+      'APP_SESSION_OPENED:u1:550e8400-e29b-41d4-a716-446655440000',
+    );
+  });
+
   it('records an allowlisted app session event with APP source', async () => {
+    const sessionId = '550e8400-e29b-41d4-a716-446655440000';
     userEventService.record.mockResolvedValue({
       event: {
         id: 'evt-1',
@@ -30,7 +46,7 @@ describe('ClientEventService', () => {
         source: EventSource.APP,
         createdAt: new Date('2026-07-30T12:00:00Z'),
         metadata: {
-          sessionId: 's1',
+          sessionId,
           subject: { type: 'USER', id: 'u1' },
         },
         groupId: null,
@@ -41,16 +57,15 @@ describe('ClientEventService', () => {
     const result = await service.record({
       userId: 'u1',
       eventType: EventType.APP_SESSION_OPENED,
-      metadata: { sessionId: 's1' },
-      idempotencyKey: 'app-session-opened:u1:s1',
+      metadata: { sessionId, platform: 'ios' },
     });
 
     expect(userEventService.record).toHaveBeenCalledWith({
       userId: 'u1',
       eventType: EventType.APP_SESSION_OPENED,
       source: EventSource.APP,
-      metadata: { sessionId: 's1' },
-      idempotencyKey: 'app-session-opened:u1:s1',
+      metadata: { sessionId, platform: 'ios' },
+      idempotencyKey: `APP_SESSION_OPENED:u1:${sessionId}`,
       subject: { type: 'USER', id: 'u1' },
     });
     expect(result.replayed).toBe(false);
@@ -65,6 +80,7 @@ describe('ClientEventService', () => {
   });
 
   it('returns replayed events without changing the DTO shape', async () => {
+    const sessionId = '550e8400-e29b-41d4-a716-446655440000';
     userEventService.record.mockResolvedValue({
       event: {
         id: 'evt-existing',
@@ -72,7 +88,7 @@ describe('ClientEventService', () => {
         eventType: EventType.APP_SESSION_ENDED,
         source: EventSource.APP,
         createdAt: new Date('2026-07-30T12:05:00Z'),
-        metadata: { sessionId: 's1', durationSeconds: 300 },
+        metadata: { sessionId, durationSeconds: 300 },
         groupId: null,
       },
       replayed: true,
@@ -81,10 +97,14 @@ describe('ClientEventService', () => {
     const result = await service.record({
       userId: 'u1',
       eventType: EventType.APP_SESSION_ENDED,
-      metadata: { sessionId: 's1', durationSeconds: 300 },
-      idempotencyKey: 'app-session-ended:u1:s1',
+      metadata: { sessionId, durationSeconds: 300 },
     });
 
+    expect(userEventService.record).toHaveBeenCalledWith(
+      expect.objectContaining({
+        idempotencyKey: `APP_SESSION_ENDED:u1:${sessionId}`,
+      }),
+    );
     expect(result.replayed).toBe(true);
     expect(result.event.id).toBe('evt-existing');
   });

--- a/src/events/services/client-event.service.spec.ts
+++ b/src/events/services/client-event.service.spec.ts
@@ -1,0 +1,91 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { EventSource, EventType } from '../event-types';
+import { ClientEventService } from './client-event.service';
+import { UserEventService } from './user-event.service';
+
+describe('ClientEventService', () => {
+  let service: ClientEventService;
+  const userEventService = {
+    record: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ClientEventService,
+        { provide: UserEventService, useValue: userEventService },
+      ],
+    }).compile();
+
+    service = module.get(ClientEventService);
+    jest.clearAllMocks();
+  });
+
+  it('records an allowlisted app session event with APP source', async () => {
+    userEventService.record.mockResolvedValue({
+      event: {
+        id: 'evt-1',
+        userId: 'u1',
+        eventType: EventType.APP_SESSION_OPENED,
+        source: EventSource.APP,
+        createdAt: new Date('2026-07-30T12:00:00Z'),
+        metadata: {
+          sessionId: 's1',
+          subject: { type: 'USER', id: 'u1' },
+        },
+        groupId: null,
+      },
+      replayed: false,
+    });
+
+    const result = await service.record({
+      userId: 'u1',
+      eventType: EventType.APP_SESSION_OPENED,
+      metadata: { sessionId: 's1' },
+      idempotencyKey: 'app-session-opened:u1:s1',
+    });
+
+    expect(userEventService.record).toHaveBeenCalledWith({
+      userId: 'u1',
+      eventType: EventType.APP_SESSION_OPENED,
+      source: EventSource.APP,
+      metadata: { sessionId: 's1' },
+      idempotencyKey: 'app-session-opened:u1:s1',
+      subject: { type: 'USER', id: 'u1' },
+    });
+    expect(result.replayed).toBe(false);
+    expect(result.event).toEqual(
+      expect.objectContaining({
+        id: 'evt-1',
+        eventType: EventType.APP_SESSION_OPENED,
+        source: EventSource.APP,
+        timestamp: new Date('2026-07-30T12:00:00Z'),
+      }),
+    );
+  });
+
+  it('returns replayed events without changing the DTO shape', async () => {
+    userEventService.record.mockResolvedValue({
+      event: {
+        id: 'evt-existing',
+        userId: 'u1',
+        eventType: EventType.APP_SESSION_ENDED,
+        source: EventSource.APP,
+        createdAt: new Date('2026-07-30T12:05:00Z'),
+        metadata: { sessionId: 's1', durationSeconds: 300 },
+        groupId: null,
+      },
+      replayed: true,
+    });
+
+    const result = await service.record({
+      userId: 'u1',
+      eventType: EventType.APP_SESSION_ENDED,
+      metadata: { sessionId: 's1', durationSeconds: 300 },
+      idempotencyKey: 'app-session-ended:u1:s1',
+    });
+
+    expect(result.replayed).toBe(true);
+    expect(result.event.id).toBe('evt-existing');
+  });
+});

--- a/src/events/services/client-event.service.spec.ts
+++ b/src/events/services/client-event.service.spec.ts
@@ -31,9 +31,7 @@ describe('ClientEventService', () => {
         'u1',
         '550e8400-e29b-41d4-a716-446655440000',
       ),
-    ).toBe(
-      'APP_SESSION_OPENED:u1:550e8400-e29b-41d4-a716-446655440000',
-    );
+    ).toBe('APP_SESSION_OPENED:u1:550e8400-e29b-41d4-a716-446655440000');
   });
 
   it('records an allowlisted app session event with APP source', async () => {

--- a/src/events/services/client-event.service.ts
+++ b/src/events/services/client-event.service.ts
@@ -1,0 +1,50 @@
+import { Injectable } from '@nestjs/common';
+import { UserEvent } from '@prisma/client';
+import {
+  EventSource,
+  EventSubjectType,
+  ClientRecordableEventType,
+} from '../event-types';
+import { UserEventDto } from '../dto/user-event.dto';
+import { UserEventService } from './user-event.service';
+import { asObjectMetadata } from '../user-event.utils';
+
+export interface RecordClientEventInput {
+  userId: string;
+  eventType: ClientRecordableEventType;
+  metadata?: Record<string, unknown>;
+  idempotencyKey?: string;
+}
+
+@Injectable()
+export class ClientEventService {
+  constructor(private readonly userEventService: UserEventService) {}
+
+  async record(input: RecordClientEventInput): Promise<{
+    event: UserEventDto;
+    replayed: boolean;
+  }> {
+    const { event, replayed } = await this.userEventService.record({
+      userId: input.userId,
+      eventType: input.eventType,
+      source: EventSource.APP,
+      metadata: input.metadata,
+      idempotencyKey: input.idempotencyKey,
+      subject: { type: EventSubjectType.USER, id: input.userId },
+    });
+
+    return { event: this.toDto(event), replayed };
+  }
+
+  private toDto(event: UserEvent): UserEventDto {
+    return {
+      id: event.id,
+      userId: event.userId,
+      eventType: event.eventType,
+      source: event.source,
+      timestamp: event.createdAt,
+      metadata: asObjectMetadata(event.metadata),
+      groupId: event.groupId,
+    };
+  }
+}

--- a/src/events/services/client-event.service.ts
+++ b/src/events/services/client-event.service.ts
@@ -1,19 +1,32 @@
 import { Injectable } from '@nestjs/common';
 import { UserEvent } from '@prisma/client';
 import {
+  ClientRecordableEventType,
   EventSource,
   EventSubjectType,
-  ClientRecordableEventType,
 } from '../event-types';
+import { ClientEventMetadataDto } from '../dto/create-client-event.dto';
 import { UserEventDto } from '../dto/user-event.dto';
-import { UserEventService } from './user-event.service';
 import { asObjectMetadata } from '../user-event.utils';
+import { UserEventService } from './user-event.service';
 
 export interface RecordClientEventInput {
   userId: string;
   eventType: ClientRecordableEventType;
-  metadata?: Record<string, unknown>;
-  idempotencyKey?: string;
+  metadata: ClientEventMetadataDto;
+}
+
+/**
+ * Server-owned idempotency key. Includes authenticated userId so keys cannot
+ * collide or leak across users. Do not use timestamps — retries must reuse the
+ * same key.
+ */
+export function buildClientEventIdempotencyKey(
+  eventType: ClientRecordableEventType,
+  userId: string,
+  sessionId: string,
+): string {
+  return `${eventType}:${userId}:${sessionId}`;
 }
 
 @Injectable()
@@ -24,12 +37,31 @@ export class ClientEventService {
     event: UserEventDto;
     replayed: boolean;
   }> {
+    const idempotencyKey = buildClientEventIdempotencyKey(
+      input.eventType,
+      input.userId,
+      input.metadata.sessionId,
+    );
+
+    const metadata: Record<string, unknown> = {
+      sessionId: input.metadata.sessionId,
+      ...(input.metadata.platform != null
+        ? { platform: input.metadata.platform }
+        : {}),
+      ...(input.metadata.appVersion != null
+        ? { appVersion: input.metadata.appVersion }
+        : {}),
+      ...(input.metadata.durationSeconds != null
+        ? { durationSeconds: input.metadata.durationSeconds }
+        : {}),
+    };
+
     const { event, replayed } = await this.userEventService.record({
       userId: input.userId,
       eventType: input.eventType,
       source: EventSource.APP,
-      metadata: input.metadata,
-      idempotencyKey: input.idempotencyKey,
+      metadata,
+      idempotencyKey,
       subject: { type: EventSubjectType.USER, id: input.userId },
     });
 


### PR DESCRIPTION
## Summary
- Replace unused `APP_OPENED` with `APP_SESSION_OPENED` and add `APP_SESSION_ENDED`.
- Add authenticated, throttled `POST /api/v1/events` that accepts only allowlisted client event types and records them via `UserEventService` (`source: app`).
- Update event emission guide for the limited client path.

## Test plan
- [ ] Unit: `npx jest --testPathPatterns="src/events/.*\\.spec\\.ts$"`
- [ ] Manual: obtain a user JWT, then:

```bash
# Session opened
curl -sS -X POST "$BASE_URL/api/v1/events" \
  -H "Authorization: Bearer $TOKEN" \
  -H "Content-Type: application/json" \
  -d '{
  "eventType": "APP_SESSION_OPENED",
  "metadata": {
    "sessionId": "550e8400-e29b-41d4-a716-446655440000",
    "platform": "ios",
    "appVersion": "1.0.0"
  }
}'

# Session ended (with optional duration)
curl -sS -X POST "$BASE_URL/api/v1/events" \
  -H "Authorization: Bearer $TOKEN" \
  -H "Content-Type: application/json" \
  -d '{
  "eventType": "APP_SESSION_ENDED",
  "metadata": {
    "sessionId": "550e8400-e29b-41d4-a716-446655440000",
    "durationSeconds": 420
  }
}'

---

## 🐳 Docker Image Preview

**Available tags:**
- `ghcr.io/reedu-reengineering-education/foodmission-data-framework:pr-273`
- `ghcr.io/reedu-reengineering-education/foodmission-data-framework:sha-3c02964`

**Pull and test:**
```bash
docker pull ghcr.io/reedu-reengineering-education/foodmission-data-framework:pr-273
docker run -p 3000:3000 ghcr.io/reedu-reengineering-education/foodmission-data-framework:pr-273
```

**Multi-arch support:** ✅ AMD64 & ARM64
