### PR TITLE
feat: add translations usage for off (food-products)

### DIFF
--- a/src/common/decorators/api-query-params.decorator.spec.ts
+++ b/src/common/decorators/api-query-params.decorator.spec.ts
@@ -23,7 +23,15 @@ describe('ApiQueryParamsDecorators', () => {
       const names = metadata.map((m: any) => m.name);
 
       expect(new Set(names)).toEqual(
-        new Set(['query', 'category', 'brand', 'page', 'pageSize', 'limit']),
+        new Set([
+          'query',
+          'category',
+          'brand',
+          'page',
+          'pageSize',
+          'limit',
+          'lang',
+        ]),
       );
 
       expect(metadata.find((m: any) => m.name === 'query')?.type).toBe(String);

--- a/src/common/decorators/api-query-params.decorator.ts
+++ b/src/common/decorators/api-query-params.decorator.ts
@@ -100,5 +100,12 @@ export function ApiOpenFoodFactsSearchQuery() {
       description:
         'Items per page (alternative to pageSize, for backward compatibility, min: 1, max: 50)',
     }),
+    ApiQuery({
+      name: 'lang',
+      required: false,
+      type: String,
+      description:
+        'Optional locale for product name / ingredients (supported project locales; unsupported codes fall back to en)',
+    }),
   );
 }

--- a/src/food-products/controllers/food-products.controller.spec.ts
+++ b/src/food-products/controllers/food-products.controller.spec.ts
@@ -52,13 +52,27 @@ describe('FoodProductController', () => {
     it('passes includeOpenFoodFacts=false when query omitted', async () => {
       service.findOne.mockResolvedValue(foodDto);
       await controller.findOne(TEST_FOOD.id, undefined);
-      expect(service.findOne).toHaveBeenCalledWith(TEST_FOOD.id, false);
+      expect(service.findOne).toHaveBeenCalledWith(
+        TEST_FOOD.id,
+        false,
+        undefined,
+      );
     });
 
     it('passes includeOpenFoodFacts=true when query is "true"', async () => {
       service.findOne.mockResolvedValue(foodDto);
       await controller.findOne(TEST_FOOD.id, 'true');
-      expect(service.findOne).toHaveBeenCalledWith(TEST_FOOD.id, true);
+      expect(service.findOne).toHaveBeenCalledWith(
+        TEST_FOOD.id,
+        true,
+        undefined,
+      );
+    });
+
+    it('passes lang to service when provided', async () => {
+      service.findOne.mockResolvedValue(foodDto);
+      await controller.findOne(TEST_FOOD.id, 'true', 'de');
+      expect(service.findOne).toHaveBeenCalledWith(TEST_FOOD.id, true, 'de');
     });
 
     it('propagates NotFoundException from service', async () => {
@@ -75,7 +89,19 @@ describe('FoodProductController', () => {
     it('delegates to service.findByBarcode', async () => {
       service.findByBarcode.mockResolvedValue(foodDto);
       await controller.findByBarcode(TEST_FOOD.barcode);
-      expect(service.findByBarcode).toHaveBeenCalledWith(TEST_FOOD.barcode);
+      expect(service.findByBarcode).toHaveBeenCalledWith(
+        TEST_FOOD.barcode,
+        undefined,
+      );
+    });
+
+    it('forwards lang query to service', async () => {
+      service.findByBarcode.mockResolvedValue(foodDto);
+      await controller.findByBarcode(TEST_FOOD.barcode, 'de');
+      expect(service.findByBarcode).toHaveBeenCalledWith(
+        TEST_FOOD.barcode,
+        'de',
+      );
     });
   });
 
@@ -163,8 +189,19 @@ describe('FoodProductController', () => {
       expect(service.findOne).toHaveBeenCalledWith(TEST_FOOD.id);
       expect(service.getOpenFoodFactsInfo).toHaveBeenCalledWith(
         TEST_FOOD.barcode,
+        undefined,
       );
       expect(result).toEqual(offPayload);
+    });
+
+    it('forwards lang to getOpenFoodFactsInfo', async () => {
+      service.findOne.mockResolvedValue(foodDto);
+      service.getOpenFoodFactsInfo.mockResolvedValue({ name: 'Apfel' } as any);
+      await controller.getOpenFoodFactsInfo(TEST_FOOD.id, 'de');
+      expect(service.getOpenFoodFactsInfo).toHaveBeenCalledWith(
+        TEST_FOOD.barcode,
+        'de',
+      );
     });
   });
 });

--- a/src/food-products/controllers/food-products.controller.ts
+++ b/src/food-products/controllers/food-products.controller.ts
@@ -43,6 +43,7 @@ import { CacheEvictInterceptor } from '../../cache/cache-evict.interceptor';
 import { Cacheable, CacheEvict } from '../../cache/decorators/cache.decorator';
 import { CurrentUser } from '../../common/decorators/current-user.decorator';
 import { DataBaseAuthGuard } from '../../common/guards/database-auth.guards';
+import { DEFAULT_LOCALE, SUPPORTED_LOCALES } from '../../i18n/constants';
 
 @ApiTags('food-products')
 @Controller('food-products')
@@ -179,9 +180,16 @@ export class FoodProductController {
   @Public()
   @ApiOperation({
     summary: 'Find food product by barcode',
-    description: 'Retrieves product information from OpenFoodFacts.',
+    description:
+      'Retrieves product information from OpenFoodFacts. Use lang to prefer localized name/ingredients when available.',
   })
   @ApiParam({ name: 'barcode', type: 'string', description: 'Product barcode' })
+  @ApiQuery({
+    name: 'lang',
+    required: false,
+    enum: SUPPORTED_LOCALES,
+    description: `Optional locale for product name / ingredients. Defaults to ${DEFAULT_LOCALE}. Unsupported codes fall back to ${DEFAULT_LOCALE}.`,
+  })
   @ApiResponse({
     status: 200,
     description: 'Food product found',
@@ -190,8 +198,9 @@ export class FoodProductController {
   @ApiCommonErrorResponses({ notFound: true, unauthorized: false })
   findByBarcode(
     @Param('barcode') barcode: string,
+    @Query('lang') lang?: string,
   ): Promise<FoodProductResponseDto> {
-    return this.foodProductService.findByBarcode(barcode);
+    return this.foodProductService.findByBarcode(barcode, lang);
   }
 
   @Get(':id')
@@ -214,6 +223,12 @@ export class FoodProductController {
     type: 'boolean',
     description: 'Include OpenFoodFacts information in response',
   })
+  @ApiQuery({
+    name: 'lang',
+    required: false,
+    enum: SUPPORTED_LOCALES,
+    description: `Optional locale for OpenFoodFacts overlay text. Defaults to ${DEFAULT_LOCALE}. Unsupported codes fall back to ${DEFAULT_LOCALE}.`,
+  })
   @ApiResponse({
     status: 200,
     description: 'Food product found',
@@ -223,9 +238,10 @@ export class FoodProductController {
   findOne(
     @Param('id', ParseUUIDPipe) id: string,
     @Query('includeOpenFoodFacts') includeOpenFoodFacts?: string,
+    @Query('lang') lang?: string,
   ): Promise<FoodProductResponseDto> {
     const includeOff = includeOpenFoodFacts === 'true';
-    return this.foodProductService.findOne(id, includeOff);
+    return this.foodProductService.findOne(id, includeOff, lang);
   }
 
   @Patch(':id')
@@ -301,13 +317,19 @@ export class FoodProductController {
   @ApiOperation({
     summary: 'Get OpenFoodFacts information for food product',
     description:
-      'Retrieves OpenFoodFacts information for a food product by its ID when the product has a barcode.',
+      'Retrieves OpenFoodFacts information for a food product by its ID when the product has a barcode. Use lang to prefer localized name/ingredients when available.',
   })
   @ApiParam({
     name: 'id',
     type: 'string',
     format: 'uuid',
     description: 'Food product ID',
+  })
+  @ApiQuery({
+    name: 'lang',
+    required: false,
+    enum: SUPPORTED_LOCALES,
+    description: `Optional locale for product name / ingredients. Defaults to ${DEFAULT_LOCALE}. Unsupported codes fall back to ${DEFAULT_LOCALE}.`,
   })
   @ApiResponse({
     status: 200,
@@ -324,11 +346,14 @@ export class FoodProductController {
     unauthorized: false,
     custom: [{ status: 503, description: 'OpenFoodFacts service unavailable' }],
   })
-  async getOpenFoodFactsInfo(@Param('id', ParseUUIDPipe) id: string) {
+  async getOpenFoodFactsInfo(
+    @Param('id', ParseUUIDPipe) id: string,
+    @Query('lang') lang?: string,
+  ) {
     const food = await this.foodProductService.findOne(id);
     if (!food.barcode) {
       return null;
     }
-    return this.foodProductService.getOpenFoodFactsInfo(food.barcode);
+    return this.foodProductService.getOpenFoodFactsInfo(food.barcode, lang);
   }
 }

--- a/src/food-products/dto/food-product-query.dto.ts
+++ b/src/food-products/dto/food-product-query.dto.ts
@@ -1,5 +1,8 @@
 import { IsOptional, IsString, IsInt, Min, Max, IsIn } from 'class-validator';
 import { Type, Transform } from 'class-transformer';
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { DEFAULT_LOCALE, SUPPORTED_LOCALES } from '../../i18n/constants';
+import { TransformTrimLowercaseToUndefined } from '../../common/decorators/transformers';
 
 export class FoodProductQueryDto {
   @IsOptional()
@@ -36,6 +39,17 @@ export class FoodProductQueryDto {
   @IsOptional()
   @Transform(({ value }) => value === 'true')
   includeOpenFoodFacts?: boolean = false;
+
+  @ApiPropertyOptional({
+    description: `Optional locale for OpenFoodFacts overlay text (name, ingredients). Defaults to ${DEFAULT_LOCALE}. Unsupported codes fall back to ${DEFAULT_LOCALE}.`,
+    enum: SUPPORTED_LOCALES,
+    example: 'de',
+  })
+  @IsOptional()
+  @IsString()
+  @IsIn([...SUPPORTED_LOCALES])
+  @TransformTrimLowercaseToUndefined()
+  lang?: string;
 }
 
 export class FoodProductSearchDto {
@@ -70,4 +84,15 @@ export class FoodProductSearchDto {
   @Min(1)
   @Max(100)
   limit?: number = 10;
+
+  @ApiPropertyOptional({
+    description: `Optional locale for OpenFoodFacts product name / ingredients. Defaults to ${DEFAULT_LOCALE}. Unsupported codes fall back to ${DEFAULT_LOCALE}.`,
+    enum: SUPPORTED_LOCALES,
+    example: 'de',
+  })
+  @IsOptional()
+  @IsString()
+  @IsIn([...SUPPORTED_LOCALES])
+  @TransformTrimLowercaseToUndefined()
+  lang?: string;
 }

--- a/src/food-products/interfaces/openfoodfacts.interface.ts
+++ b/src/food-products/interfaces/openfoodfacts.interface.ts
@@ -190,6 +190,8 @@ export interface OpenFoodFactsSearchOptions {
     | 'completeness'
     | 'popularity';
   fields?: string[];
+  /** Resolved locale for name / ingredients / genericName (e.g. de, nl). */
+  lang?: string;
 }
 
 export interface OpenFoodFactsError {

--- a/src/food-products/repositories/off-mongo-product.repository.ts
+++ b/src/food-products/repositories/off-mongo-product.repository.ts
@@ -18,8 +18,23 @@ export class OffMongoProductRepository {
     return this.prisma.isConfigured;
   }
 
-  findByBarcode(barcode: string) {
-    return this.prisma.offProduct.findUnique({ where: { id: barcode } });
+  /**
+   * Load a product by barcode via findRaw so language-suffixed fields
+   * (product_name_de, ingredients_text_nl, …) survive. Prisma's typed
+   * findUnique only returns schema-declared columns (en + bare).
+   */
+  async findByBarcode(
+    barcode: string,
+  ): Promise<Record<string, unknown> | null> {
+    const rawItems = await this.prisma.offProduct.findRaw({
+      filter: { _id: barcode } as Prisma.InputJsonValue,
+    });
+    const items = rawItems as unknown as Record<string, unknown>[];
+    if (!items?.length) {
+      return null;
+    }
+    const doc = items[0];
+    return { ...doc, id: doc._id };
   }
 
   // Uses findRaw/aggregateRaw instead of Prisma's regular query builder.

--- a/src/food-products/services/food-product.service.spec.ts
+++ b/src/food-products/services/food-product.service.spec.ts
@@ -6,6 +6,10 @@ import { compileFoodProductServiceTestingModule } from '../../../test/test-utils
 describe('FoodProductService', () => {
   let service: FoodProductService;
   let repository: jest.Mocked<FoodProductRepository>;
+  let openFoodFacts: {
+    getProductByBarcode: jest.Mock;
+    searchProducts: jest.Mock;
+  };
 
   const mockFood = {
     id: 'food-1',
@@ -19,6 +23,7 @@ describe('FoodProductService', () => {
     service = setup.service;
     repository =
       setup.repository as unknown as jest.Mocked<FoodProductRepository>;
+    openFoodFacts = setup.openFoodFacts;
   });
 
   afterEach(() => jest.clearAllMocks());
@@ -46,6 +51,79 @@ describe('FoodProductService', () => {
   it('throws when finding missing food by id', async () => {
     repository.findById.mockResolvedValue(null);
     await expect(service.findOne('missing')).rejects.toThrow(NotFoundException);
+  });
+
+  describe('findByBarcode lang', () => {
+    it('passes resolved locale to OpenFoodFactsService', async () => {
+      openFoodFacts.getProductByBarcode.mockResolvedValue({
+        barcode: '123',
+        name: 'Nougatcreme',
+        genericName: 'Haselnusscreme',
+      });
+
+      const result = await service.findByBarcode('123', 'de');
+
+      expect(openFoodFacts.getProductByBarcode).toHaveBeenCalledWith(
+        '123',
+        'de',
+      );
+      expect(result.name).toBe('Nougatcreme');
+    });
+
+    it('defaults to en when lang omitted', async () => {
+      openFoodFacts.getProductByBarcode.mockResolvedValue({
+        barcode: '123',
+        name: 'Nutella',
+      });
+
+      await service.findByBarcode('123');
+
+      expect(openFoodFacts.getProductByBarcode).toHaveBeenCalledWith(
+        '123',
+        'en',
+      );
+    });
+  });
+
+  describe('searchOpenFoodFacts lang', () => {
+    it('includes resolved lang in search options', async () => {
+      openFoodFacts.searchProducts.mockResolvedValue({
+        products: [],
+        totalCount: 0,
+        page: 1,
+        pageSize: 10,
+        totalPages: 0,
+      });
+
+      await service.searchOpenFoodFacts({ query: 'nutella', lang: 'de' });
+
+      expect(openFoodFacts.searchProducts).toHaveBeenCalledWith(
+        expect.objectContaining({ query: 'nutella', lang: 'de' }),
+      );
+    });
+  });
+
+  describe('importFromOpenFoodFacts', () => {
+    it('always imports with English locale', async () => {
+      repository.findByBarcode.mockResolvedValue(null);
+      openFoodFacts.getProductByBarcode.mockResolvedValue({
+        barcode: '999',
+        name: 'Nutella',
+        genericName: 'Hazelnut spread',
+      });
+      repository.create.mockResolvedValue({
+        id: 'imported',
+        name: 'Nutella',
+        barcode: '999',
+      } as any);
+
+      await service.importFromOpenFoodFacts('999', 'user-1');
+
+      expect(openFoodFacts.getProductByBarcode).toHaveBeenCalledWith(
+        '999',
+        'en',
+      );
+    });
   });
 
   describe('remove', () => {

--- a/src/food-products/services/food-product.service.ts
+++ b/src/food-products/services/food-product.service.ts
@@ -19,6 +19,8 @@ import {
   PaginatedFoodProductResponseDto,
 } from '../dto/food-product-response.dto';
 import { plainToClass } from 'class-transformer';
+import { TranslationService } from '../../translations/services/translation.service';
+import { DEFAULT_LOCALE } from '../../i18n/constants';
 
 @Injectable()
 export class FoodProductService {
@@ -27,6 +29,7 @@ export class FoodProductService {
   constructor(
     private readonly foodProductRepository: FoodProductRepository,
     private readonly openFoodFactsService: OpenFoodFactsService,
+    private readonly translationService: TranslationService,
   ) {}
 
   async create(
@@ -94,7 +97,10 @@ export class FoodProductService {
         const responseDto = this.transformToResponseDto(food);
 
         if (query.includeOpenFoodFacts && food.barcode) {
-          const offInfo = await this.getOpenFoodFactsInfo(food.barcode);
+          const offInfo = await this.getOpenFoodFactsInfo(
+            food.barcode,
+            query.lang,
+          );
           responseDto.openFoodFactsInfo = offInfo || undefined;
         }
 
@@ -114,6 +120,7 @@ export class FoodProductService {
   async findOne(
     id: string,
     includeOpenFoodFacts: boolean = false,
+    lang?: string,
   ): Promise<FoodProductResponseDto> {
     this.logger.log(`Finding food by id: ${id}`);
 
@@ -130,18 +137,24 @@ export class FoodProductService {
       this.logger.debug(
         `Fetching OpenFoodFacts info for barcode: ${food.barcode}`,
       );
-      const offInfo = await this.getOpenFoodFactsInfo(food.barcode);
+      const offInfo = await this.getOpenFoodFactsInfo(food.barcode, lang);
       responseDto.openFoodFactsInfo = offInfo || undefined;
     }
 
     return responseDto;
   }
 
-  async findByBarcode(barcode: string): Promise<FoodProductResponseDto> {
+  async findByBarcode(
+    barcode: string,
+    lang?: string,
+  ): Promise<FoodProductResponseDto> {
     this.logger.log(`Finding food by barcode: ${barcode}`);
 
-    const offProduct =
-      await this.openFoodFactsService.getProductByBarcode(barcode);
+    const locale = this.translationService.resolveLocale(lang);
+    const offProduct = await this.openFoodFactsService.getProductByBarcode(
+      barcode,
+      locale,
+    );
     if (!offProduct) {
       throw new NotFoundException('Food product not found');
     }
@@ -198,6 +211,7 @@ export class FoodProductService {
       brands: searchDto.brand ? [searchDto.brand] : undefined,
       page: searchDto.page || 1,
       pageSize: searchDto.pageSize || searchDto.limit || 10,
+      lang: this.translationService.resolveLocale(searchDto.lang),
     };
 
     return await this.openFoodFactsService.searchProducts(searchOptions);
@@ -215,8 +229,11 @@ export class FoodProductService {
       throw new BadRequestException('Food with this barcode already exists');
     }
 
-    const productInfo =
-      await this.openFoodFactsService.getProductByBarcode(barcode);
+    // Persist English-preferred snapshot for stable DB content.
+    const productInfo = await this.openFoodFactsService.getProductByBarcode(
+      barcode,
+      DEFAULT_LOCALE,
+    );
     if (!productInfo) {
       throw new NotFoundException('Product not found in OpenFoodFacts');
     }
@@ -233,10 +250,14 @@ export class FoodProductService {
 
   async getOpenFoodFactsInfo(
     barcode: string,
+    lang?: string,
   ): Promise<OpenFoodFactsInfoDto | null> {
     try {
-      const productInfo =
-        await this.openFoodFactsService.getProductByBarcode(barcode);
+      const locale = this.translationService.resolveLocale(lang);
+      const productInfo = await this.openFoodFactsService.getProductByBarcode(
+        barcode,
+        locale,
+      );
       if (!productInfo) {
         return null;
       }

--- a/src/food-products/services/openfoodfacts.service.spec.ts
+++ b/src/food-products/services/openfoodfacts.service.spec.ts
@@ -133,6 +133,7 @@ describe('OpenFoodFactsService', () => {
       expect(result?.nutritionalInfo?.energyKcal).toBe(539);
       expect(httpService.get).toHaveBeenCalledWith(
         'https://world.openfoodfacts.org/api/v0/product/3017620422003.json',
+        { params: { lc: 'en' } },
       );
     });
 
@@ -279,6 +280,7 @@ describe('OpenFoodFactsService', () => {
             json: 1,
             search_terms: 'nutella',
             page_size: 20,
+            lc: 'en',
           }),
         }),
       );
@@ -490,6 +492,117 @@ describe('OpenFoodFactsService', () => {
           }),
         }),
       );
+    });
+  });
+
+  describe('locale-aware transform', () => {
+    it('prefers product_name_de when lang=de', async () => {
+      const localizedProduct: OpenFoodFactsProduct = {
+        ...mockProduct,
+        product: {
+          ...mockProduct.product,
+          product_name: 'Nutella',
+          product_name_en: 'Nutella EN',
+          product_name_de: 'Nougatcreme',
+          ingredients_text: 'Sugar',
+          ingredients_text_en: 'Sugar, palm oil',
+          ingredients_text_de: 'Zucker, Palmöl',
+          generic_name: 'Hazelnut spread',
+          generic_name_de: 'Haselnusscreme',
+        } as any,
+      };
+
+      const mockResponse: AxiosResponse<OpenFoodFactsProduct> = {
+        data: localizedProduct,
+        status: 200,
+        statusText: 'OK',
+        headers: {},
+        config: {} as any,
+      };
+      httpService.get.mockReturnValueOnce(of(mockResponse));
+
+      const result = await service.getProductByBarcode('3017620422003', 'de');
+
+      expect(result?.name).toBe('Nougatcreme');
+      expect(result?.genericName).toBe('Haselnusscreme');
+      expect(result?.ingredients).toBe('Zucker, Palmöl');
+      expect(httpService.get).toHaveBeenCalledWith(
+        'https://world.openfoodfacts.org/api/v0/product/3017620422003.json',
+        { params: { lc: 'de' } },
+      );
+    });
+
+    it('falls back to English name when requested locale is missing', async () => {
+      const mockResponse: AxiosResponse<OpenFoodFactsProduct> = {
+        data: mockProduct,
+        status: 200,
+        statusText: 'OK',
+        headers: {},
+        config: {} as any,
+      };
+      httpService.get.mockReturnValueOnce(of(mockResponse));
+
+      const result = await service.getProductByBarcode('3017620422003', 'de');
+
+      expect(result?.name).toBe('Nutella');
+      expect(result?.ingredients).toBe(
+        'Sugar, palm oil, hazelnuts, cocoa, milk powder',
+      );
+    });
+
+    it('passes lc on search and localizes product names', async () => {
+      const mockResponse: AxiosResponse<OpenFoodFactsSearchResponse> = {
+        data: {
+          ...mockSearchResponse,
+          products: [
+            {
+              product_name: 'Nutella',
+              product_name_en: 'Nutella EN',
+              product_name_de: 'Nougatcreme',
+              brands: 'Ferrero',
+              categories_tags: ['en:sweet-spreads'],
+            } as any,
+          ],
+        },
+        status: 200,
+        statusText: 'OK',
+        headers: {},
+        config: {} as any,
+      };
+      httpService.get.mockReturnValueOnce(of(mockResponse));
+
+      const result = await service.searchProducts({
+        query: 'nutella',
+        lang: 'de',
+      });
+
+      expect(result.products[0].name).toBe('Nougatcreme');
+      expect(httpService.get).toHaveBeenCalledWith(
+        'https://world.openfoodfacts.org/cgi/search.pl',
+        expect.objectContaining({
+          params: expect.objectContaining({
+            lc: 'de',
+            search_terms: 'nutella',
+          }),
+        }),
+      );
+    });
+
+    it('localizes from Mongo documents with language-suffixed fields', async () => {
+      mockOffMongoRepository.isAvailable = true;
+      mockOffMongoRepository.findByBarcode.mockResolvedValueOnce({
+        id: '3017620422003',
+        _id: '3017620422003',
+        product_name: 'Nutella',
+        product_name_en: 'Nutella EN',
+        product_name_de: 'Nougatcreme',
+        brands: 'Ferrero',
+      });
+
+      const result = await service.getProductByBarcode('3017620422003', 'de');
+
+      expect(result?.name).toBe('Nougatcreme');
+      expect(httpService.get).not.toHaveBeenCalled();
     });
   });
 

--- a/src/food-products/services/openfoodfacts.service.ts
+++ b/src/food-products/services/openfoodfacts.service.ts
@@ -12,6 +12,8 @@ import {
   OpenFoodFactsSearchOptions,
   OpenFoodFactsNutriments,
 } from '../interfaces/openfoodfacts.interface';
+import { DEFAULT_LOCALE } from '../../i18n/constants';
+import { pickLocalizedString } from '../utils/off-locale';
 
 @Injectable()
 export class OpenFoodFactsService {
@@ -31,14 +33,20 @@ export class OpenFoodFactsService {
    * Tries the local OpenFoodFacts MongoDB clone first, falling back to the
    * live HTTP API if the clone is unconfigured, unreachable, or errors.
    */
-  async getProductByBarcode(barcode: string): Promise<ProductInfo | null> {
+  async getProductByBarcode(
+    barcode: string,
+    lang: string = DEFAULT_LOCALE,
+  ): Promise<ProductInfo | null> {
     if (this.offMongoRepository.isAvailable) {
       try {
         const doc = await this.withMongoTimeout(
           this.offMongoRepository.findByBarcode(barcode),
         );
         if (doc) {
-          const productInfo = this.transformProduct({ ...doc, _id: doc.id });
+          const productInfo = this.transformProduct(
+            { ...doc, _id: doc.id ?? doc._id },
+            lang,
+          );
           this.logger.log(
             `Found product in local OFF database: ${productInfo.name}`,
           );
@@ -56,18 +64,20 @@ export class OpenFoodFactsService {
       }
     }
 
-    return this.getProductByBarcodeHttp(barcode);
+    return this.getProductByBarcodeHttp(barcode, lang);
   }
 
   private async getProductByBarcodeHttp(
     barcode: string,
+    lang: string = DEFAULT_LOCALE,
   ): Promise<ProductInfo | null> {
     this.logger.log(`Fetching product by barcode: ${barcode}`);
 
     const url = `${this.baseUrl}/api/v0/product/${barcode}.json`;
+    const params = this.buildProductHttpParams(lang);
 
     const response = await this.httpService
-      .get<OpenFoodFactsProduct>(url)
+      .get<OpenFoodFactsProduct>(url, { params })
       .pipe(
         timeout(this.apiTimeout),
         retry(this.maxRetries),
@@ -81,7 +91,7 @@ export class OpenFoodFactsService {
       return null;
     }
 
-    const productInfo = this.transformProduct(response.product);
+    const productInfo = this.transformProduct(response.product, lang);
 
     this.logger.log(`Successfully fetched product: ${productInfo.name}`);
     return productInfo;
@@ -99,13 +109,15 @@ export class OpenFoodFactsService {
     pageSize: number;
     totalPages: number;
   }> {
+    const lang = options.lang ?? DEFAULT_LOCALE;
+
     if (this.offMongoRepository.isAvailable) {
       try {
         const { items, totalCount, page, pageSize } =
           await this.withMongoTimeout(this.offMongoRepository.search(options));
 
         const products = items.map((doc) =>
-          this.transformProduct({ ...doc, _id: doc.id }),
+          this.transformProduct({ ...doc, _id: doc.id }, lang),
         );
 
         this.logger.log(
@@ -132,6 +144,7 @@ export class OpenFoodFactsService {
 
   private async searchProductsHttp(options: OpenFoodFactsSearchOptions) {
     this.logger.log(`Searching products with options:`, options);
+    const lang = options.lang ?? DEFAULT_LOCALE;
 
     // Build search parameters
     const params = this.buildSearchParams(options);
@@ -160,7 +173,7 @@ export class OpenFoodFactsService {
 
     const products = response.products
       .filter((product) => product.product_name) // Only include products with names
-      .map((product) => this.transformProduct(product));
+      .map((product) => this.transformProduct(product, lang));
 
     const result = {
       products,
@@ -227,52 +240,65 @@ export class OpenFoodFactsService {
 
   // Private helper methods
 
-  private transformProduct(product: any): ProductInfo {
+  private transformProduct(
+    product: Record<string, unknown>,
+    lang: string = DEFAULT_LOCALE,
+  ): ProductInfo {
+    const brands = product.brands;
+    const nutriments = product.nutriments as
+      | OpenFoodFactsNutriments
+      | undefined;
+
     return {
-      id: product._id,
-      barcode: product._id,
-      name: this.getProductName(product),
-      genericName: product.generic_name,
-      brands: product.brands
-        ? product.brands.split(',').map((b: string) => b.trim())
-        : [],
-      categories: product.categories_tags || [],
-      labels: product.labels_tags || [],
+      id: String(product._id ?? ''),
+      barcode: String(product._id ?? ''),
+      name: this.getProductName(product, lang),
+      genericName: pickLocalizedString(product, 'generic_name', lang),
+      brands:
+        typeof brands === 'string'
+          ? brands.split(',').map((b: string) => b.trim())
+          : [],
+      categories: (product.categories_tags as string[]) || [],
+      labels: (product.labels_tags as string[]) || [],
       quantity: this.toOptionalString(product.quantity),
       servingSize: this.toOptionalString(product.serving_size),
-      packaging: product.packaging_tags || [],
-      origins: product.origins,
-      manufacturingPlaces: product.manufacturing_places,
-      ingredients: product.ingredients_text_en || product.ingredients_text,
-      allergens: product.allergens_tags || [],
-      traces: product.traces_tags || [],
-      nutritionGrade: product.nutrition_grades,
+      packaging: (product.packaging_tags as string[]) || [],
+      origins: this.toOptionalString(product.origins),
+      manufacturingPlaces: this.toOptionalString(product.manufacturing_places),
+      ingredients: pickLocalizedString(product, 'ingredients_text', lang),
+      allergens: (product.allergens_tags as string[]) || [],
+      traces: (product.traces_tags as string[]) || [],
+      nutritionGrade: this.toOptionalString(product.nutrition_grades),
       novaGroup: this.toOptionalNumber(product.nova_group),
-      ecoscoreGrade: product.ecoscore_grade,
-      carbonFootprint: product.nutriments?.[
+      ecoscoreGrade: this.toOptionalString(product.ecoscore_grade),
+      carbonFootprint: (nutriments as Record<string, unknown> | undefined)?.[
         'carbon-footprint-from-known-ingredients_product'
       ]
         ? Number(
-            product.nutriments[
+            (nutriments as Record<string, unknown>)[
               'carbon-footprint-from-known-ingredients_product'
             ],
           )
         : undefined,
-      nutritionDataPer: product.nutrition_data_per,
-      imageUrl: product.image_url,
-      imageFrontUrl: product.image_front_url,
-      imageNutritionUrl: product.image_nutrition_url,
-      imageIngredientsUrl: product.image_ingredients_url,
-      nutritionalInfo: this.transformNutriments(product.nutriments),
-      countries: product.countries_tags || [],
-      stores: product.stores_tags || [],
-      completeness: product.completeness,
-      createdAt: product.created_t
-        ? new Date(product.created_t * 1000)
-        : undefined,
-      lastModified: product.last_modified_t
-        ? new Date(product.last_modified_t * 1000)
-        : undefined,
+      nutritionDataPer: this.toOptionalString(product.nutrition_data_per),
+      imageUrl: this.toOptionalString(product.image_url),
+      imageFrontUrl: this.toOptionalString(product.image_front_url),
+      imageNutritionUrl: this.toOptionalString(product.image_nutrition_url),
+      imageIngredientsUrl: this.toOptionalString(
+        product.image_ingredients_url,
+      ),
+      nutritionalInfo: this.transformNutriments(nutriments),
+      countries: (product.countries_tags as string[]) || [],
+      stores: (product.stores_tags as string[]) || [],
+      completeness: this.toOptionalNumber(product.completeness),
+      createdAt:
+        typeof product.created_t === 'number'
+          ? new Date(product.created_t * 1000)
+          : undefined,
+      lastModified:
+        typeof product.last_modified_t === 'number'
+          ? new Date(product.last_modified_t * 1000)
+          : undefined,
     };
   }
 
@@ -292,11 +318,13 @@ export class OpenFoodFactsService {
     return Number.isNaN(num) ? undefined : num;
   }
 
-  private getProductName(product: any): string {
+  private getProductName(
+    product: Record<string, unknown>,
+    lang: string = DEFAULT_LOCALE,
+  ): string {
     return (
-      product.product_name_en ||
-      product.product_name ||
-      product.generic_name ||
+      pickLocalizedString(product, 'product_name', lang) ||
+      pickLocalizedString(product, 'generic_name', lang) ||
       'Unknown Product'
     );
   }
@@ -327,12 +355,18 @@ export class OpenFoodFactsService {
     };
   }
 
+  private buildProductHttpParams(lang: string): Record<string, string> {
+    return { lc: lang || DEFAULT_LOCALE };
+  }
+
   private buildSearchParams(options: OpenFoodFactsSearchOptions): any {
+    const lang = options.lang ?? DEFAULT_LOCALE;
     const params: any = {
       action: 'process',
       json: 1,
       page: options.page || 1,
       page_size: options.pageSize || 20,
+      lc: lang,
     };
 
     if (options.query) {

--- a/src/food-products/services/openfoodfacts.service.ts
+++ b/src/food-products/services/openfoodfacts.service.ts
@@ -246,12 +246,12 @@ export class OpenFoodFactsService {
   ): ProductInfo {
     const brands = product.brands;
     const nutriments = product.nutriments as
-      | OpenFoodFactsNutriments
-      | undefined;
+      OpenFoodFactsNutriments | undefined;
+    const id = this.toOptionalString(product._id) ?? '';
 
     return {
-      id: String(product._id ?? ''),
-      barcode: String(product._id ?? ''),
+      id,
+      barcode: id,
       name: this.getProductName(product, lang),
       genericName: pickLocalizedString(product, 'generic_name', lang),
       brands:
@@ -284,9 +284,7 @@ export class OpenFoodFactsService {
       imageUrl: this.toOptionalString(product.image_url),
       imageFrontUrl: this.toOptionalString(product.image_front_url),
       imageNutritionUrl: this.toOptionalString(product.image_nutrition_url),
-      imageIngredientsUrl: this.toOptionalString(
-        product.image_ingredients_url,
-      ),
+      imageIngredientsUrl: this.toOptionalString(product.image_ingredients_url),
       nutritionalInfo: this.transformNutriments(nutriments),
       countries: (product.countries_tags as string[]) || [],
       stores: (product.stores_tags as string[]) || [],

--- a/src/food-products/utils/off-locale.spec.ts
+++ b/src/food-products/utils/off-locale.spec.ts
@@ -1,0 +1,82 @@
+import { pickLocalizedString } from './off-locale';
+
+describe('pickLocalizedString', () => {
+  it('prefers the requested locale suffix', () => {
+    expect(
+      pickLocalizedString(
+        {
+          product_name_de: 'Nougatcreme',
+          product_name_en: 'Hazelnut spread',
+          product_name: 'Nutella',
+        },
+        'product_name',
+        'de',
+      ),
+    ).toBe('Nougatcreme');
+  });
+
+  it('falls back to English when requested locale is missing', () => {
+    expect(
+      pickLocalizedString(
+        {
+          product_name_en: 'Hazelnut spread',
+          product_name: 'Nutella',
+        },
+        'product_name',
+        'de',
+      ),
+    ).toBe('Hazelnut spread');
+  });
+
+  it('falls back to bare field when en and locale suffix are missing', () => {
+    expect(
+      pickLocalizedString(
+        {
+          product_name: 'Nutella',
+        },
+        'product_name',
+        'de',
+      ),
+    ).toBe('Nutella');
+  });
+
+  it('uses languages map as last resort', () => {
+    expect(
+      pickLocalizedString(
+        {
+          product_name_languages: {
+            de: 'Nougatcreme',
+            fr: 'Pâte à tartiner',
+          },
+        },
+        'product_name',
+        'de',
+      ),
+    ).toBe('Nougatcreme');
+  });
+
+  it('defaults to English suffix when lang is omitted', () => {
+    expect(
+      pickLocalizedString(
+        {
+          product_name_en: 'Hazelnut spread',
+          product_name: 'Nutella',
+        },
+        'product_name',
+      ),
+    ).toBe('Hazelnut spread');
+  });
+
+  it('ignores blank strings in the chain', () => {
+    expect(
+      pickLocalizedString(
+        {
+          product_name_de: '   ',
+          product_name_en: 'Hazelnut spread',
+        },
+        'product_name',
+        'de',
+      ),
+    ).toBe('Hazelnut spread');
+  });
+});

--- a/src/food-products/utils/off-locale.ts
+++ b/src/food-products/utils/off-locale.ts
@@ -1,0 +1,41 @@
+import { DEFAULT_LOCALE } from '../../i18n/constants';
+
+/**
+ * Pick a localized string from an Open Food Facts product document.
+ *
+ * Fallback chain:
+ *   `{field}_{lang}` → `{field}_en` → bare `{field}` → `{field}_languages[lang]`
+ */
+export function pickLocalizedString(
+  product: Record<string, unknown>,
+  baseField: string,
+  lang: string = DEFAULT_LOCALE,
+): string | undefined {
+  const locale = (lang || DEFAULT_LOCALE).trim().toLowerCase();
+
+  const fromSuffix = asNonEmptyString(product[`${baseField}_${locale}`]);
+  if (fromSuffix) return fromSuffix;
+
+  if (locale !== DEFAULT_LOCALE) {
+    const fromEn = asNonEmptyString(product[`${baseField}_${DEFAULT_LOCALE}`]);
+    if (fromEn) return fromEn;
+  }
+
+  const bare = asNonEmptyString(product[baseField]);
+  if (bare) return bare;
+
+  const languages = product[`${baseField}_languages`];
+  if (languages && typeof languages === 'object' && !Array.isArray(languages)) {
+    const map = languages as Record<string, unknown>;
+    const fromMap = asNonEmptyString(map[locale]);
+    if (fromMap) return fromMap;
+  }
+
+  return undefined;
+}
+
+function asNonEmptyString(value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}

--- a/test/e2e/food-products.e2e-spec.ts
+++ b/test/e2e/food-products.e2e-spec.ts
@@ -7,6 +7,7 @@ import { FoodProductController } from '../../src/food-products/controllers/food-
 import { FoodProductRepository } from '../../src/food-products/repositories/food-product.repository';
 import { FoodProductService } from '../../src/food-products/services/food-product.service';
 import { OpenFoodFactsService } from '../../src/food-products/services/openfoodfacts.service';
+import { TranslationService } from '../../src/translations/services/translation.service';
 import {
   createAuthGuardMock,
   createControllerE2eTestApp,
@@ -24,6 +25,24 @@ describe('FoodProducts endpoints (e2e)', () => {
   const openFoodFactsMock = {
     searchProducts: jest.fn(),
     getProductByBarcode: jest.fn(),
+  };
+
+  const translationService = {
+    resolveLocale: jest.fn((lang?: string) => {
+      const candidate = (lang ?? 'en').trim().toLowerCase();
+      const supported = [
+        'en',
+        'no',
+        'de',
+        'el',
+        'es',
+        'it',
+        'nl',
+        'pl',
+        'sl',
+      ];
+      return supported.includes(candidate) ? candidate : 'en';
+    }),
   };
 
   async function seedBaseData() {
@@ -58,6 +77,7 @@ describe('FoodProducts endpoints (e2e)', () => {
         FoodProductRepository,
         { provide: PrismaService, useValue: prisma },
         { provide: OpenFoodFactsService, useValue: openFoodFactsMock },
+        { provide: TranslationService, useValue: translationService },
         { provide: UserContextService, useValue: {} },
       ],
       authGuardMock: createAuthGuardMock(authUser),
@@ -134,6 +154,7 @@ describe('FoodProducts endpoints (e2e)', () => {
 
       expect(openFoodFactsMock.getProductByBarcode).toHaveBeenCalledWith(
         '1111111111111',
+        'en',
       );
       // OFF passthrough: id is the barcode, not a local FoodProduct UUID
       expect(res.body).toEqual(
@@ -145,6 +166,30 @@ describe('FoodProducts endpoints (e2e)', () => {
           brands: 'Test Brand',
         }),
       );
+    },
+  );
+
+  itIfDb(
+    'GET /food-products/barcode/:barcode?lang=de returns localized OFF name',
+    async () => {
+      openFoodFactsMock.getProductByBarcode.mockResolvedValue({
+        barcode: '1111111111111',
+        name: 'Apfel',
+        genericName: 'Frischer Apfel',
+        ingredients: 'Apfel',
+        brands: ['Test Brand'],
+      });
+
+      const res = await request(app.getHttpServer())
+        .get('/food-products/barcode/1111111111111?lang=de')
+        .expect(200);
+
+      expect(openFoodFactsMock.getProductByBarcode).toHaveBeenCalledWith(
+        '1111111111111',
+        'de',
+      );
+      expect(res.body.name).toBe('Apfel');
+      expect(res.body.description).toBe('Frischer Apfel');
     },
   );
 
@@ -176,8 +221,34 @@ describe('FoodProducts endpoints (e2e)', () => {
         )
         .expect(200);
 
-      expect(openFoodFactsMock.searchProducts).toHaveBeenCalled();
+      expect(openFoodFactsMock.searchProducts).toHaveBeenCalledWith(
+        expect.objectContaining({ lang: 'en' }),
+      );
       expect(res.body.products).toHaveLength(1);
+    },
+  );
+
+  itIfDb(
+    'GET /food-products/search/openfoodfacts?lang=de passes locale',
+    async () => {
+      openFoodFactsMock.searchProducts.mockResolvedValue({
+        products: [{ barcode: '333', name: 'OFF Produkt' }],
+        totalCount: 1,
+        page: 1,
+        pageSize: 10,
+        totalPages: 1,
+      });
+
+      const res = await request(app.getHttpServer())
+        .get(
+          '/food-products/search/openfoodfacts?query=food&page=1&pageSize=10&lang=de',
+        )
+        .expect(200);
+
+      expect(openFoodFactsMock.searchProducts).toHaveBeenCalledWith(
+        expect.objectContaining({ lang: 'de', query: 'food' }),
+      );
+      expect(res.body.products[0].name).toBe('OFF Produkt');
     },
   );
 
@@ -211,6 +282,7 @@ describe('FoodProducts endpoints (e2e)', () => {
 
       expect(openFoodFactsMock.getProductByBarcode).toHaveBeenCalledWith(
         '4444444444444',
+        'en',
       );
       expect(res.body.name).toBe('Imported OFF');
     },
@@ -265,6 +337,7 @@ describe('FoodProducts endpoints (e2e)', () => {
 
       expect(openFoodFactsMock.getProductByBarcode).toHaveBeenCalledWith(
         '1111111111111',
+        'en',
       );
       expect(res.body).toEqual(
         expect.objectContaining({ barcode: '1111111111111' }),

--- a/test/test-utils/food-product-service-testing.ts
+++ b/test/test-utils/food-product-service-testing.ts
@@ -2,6 +2,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { FoodProductService } from '../../src/food-products/services/food-product.service';
 import { FoodProductRepository } from '../../src/food-products/repositories/food-product.repository';
 import { OpenFoodFactsService } from '../../src/food-products/services/openfoodfacts.service';
+import { TranslationService } from '../../src/translations/services/translation.service';
 
 export function createMockFoodProductRepository() {
   return {
@@ -21,6 +22,26 @@ export function createMockOpenFoodFactsService() {
   };
 }
 
+export function createMockTranslationService() {
+  return {
+    resolveLocale: jest.fn((lang?: string) => {
+      const candidate = (lang ?? 'en').trim().toLowerCase();
+      const supported = [
+        'en',
+        'no',
+        'de',
+        'el',
+        'es',
+        'it',
+        'nl',
+        'pl',
+        'sl',
+      ];
+      return supported.includes(candidate) ? candidate : 'en';
+    }),
+  };
+}
+
 export type MockFoodProductRepository = ReturnType<
   typeof createMockFoodProductRepository
 >;
@@ -28,16 +49,20 @@ export type MockFoodProductRepository = ReturnType<
 export async function compileFoodProductServiceTestingModule(
   repositoryMock = createMockFoodProductRepository(),
   openFoodFactsMock = createMockOpenFoodFactsService(),
+  translationMock = createMockTranslationService(),
 ): Promise<{
   module: TestingModule;
   service: FoodProductService;
   repository: MockFoodProductRepository;
+  openFoodFacts: ReturnType<typeof createMockOpenFoodFactsService>;
+  translation: ReturnType<typeof createMockTranslationService>;
 }> {
   const module = await Test.createTestingModule({
     providers: [
       FoodProductService,
       { provide: FoodProductRepository, useValue: repositoryMock },
       { provide: OpenFoodFactsService, useValue: openFoodFactsMock },
+      { provide: TranslationService, useValue: translationMock },
     ],
   }).compile();
 
@@ -45,5 +70,7 @@ export async function compileFoodProductServiceTestingModule(
     module,
     service: module.get(FoodProductService),
     repository: module.get(FoodProductRepository),
+    openFoodFacts: openFoodFactsMock,
+    translation: translationMock,
   };
 }


### PR DESCRIPTION
# Pull Request

## Description

Use OFF db translations if available

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Security fix

## Type of Changes

- [ ] Database changes
- [ ] Schema changes (migration included)
- [ ] Seed data changes
- [x] API changes
- [ ] New Entity
- [ ] Translation updates (`src/i18n/**`)

## Changes Made

- Add `?lang=` support on Open Food Facts–backed food-product endpoints (barcode, search, OFF overlays).
- Prefer OFF multilingual fields for **name**, **genericName**, and **ingredients** with fallback: requested locale → `en` → bare packaging field → `*_languages` map.
- Read Mongo products via `findRaw` so language-suffixed fields are available; pass `lc=` on live OFF HTTP calls.
- Keep `POST .../import/openfoodfacts` English-preferred so stored Postgres snapshots stay stable.

## Testing

- [ ] `GET /food-products/barcode/{barcode}` vs `?lang=de` — name/ingredients differ when OFF has `_de` fields
- [ ] `GET /food-products/search/openfoodfacts?query=...&lang=de` — localized names where available
- [ ] `GET /food-products/:id?includeOpenFoodFacts=true&lang=de` and `.../openfoodfacts?lang=de` — overlay only; DB `name` unchanged
- [ ] Import still persists English-preferred name
- [ ] Unit tests: `npx jest --testPathPatterns='src/food-products|src/common/decorators/api-query-params'`

## Deployment Notes

- [ ] No special deployment steps required
- [ ] Environment variables added/changed
- [ ] Configuration changes required
- [ ] Database migration required
- [ ] Cache invalidation required

Special deployment instructions:

```bash
# Add any special deployment commands here
```

## Screenshots (if applicable)

Add screenshots to help explain your changes.

## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
- [ ] Translation files preserve key parity and placeholders with `en`

## Additional Notes

Add any additional notes for reviewers here. Like Related Issues, Perfomance Impact, Breaking Chances.


---

## 🐳 Docker Image Preview

**Available tags:**
- `ghcr.io/reedu-reengineering-education/foodmission-data-framework:pr-275`
- `ghcr.io/reedu-reengineering-education/foodmission-data-framework:sha-281650d`

**Pull and test:**
```bash
docker pull ghcr.io/reedu-reengineering-education/foodmission-data-framework:pr-275
docker run -p 3000:3000 ghcr.io/reedu-reengineering-education/foodmission-data-framework:pr-275
```

**Multi-arch support:** ✅ AMD64 & ARM64
