### PR TITLE
fix: translations for prod

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,10 +52,12 @@ services:
       WEBHOOK_SECRET: test-webhook-secret
     ports:
       - '127.0.0.1:8080:8080'
+    volumes:
+      - ./keycloak/foodmission-realm.dev.json:/opt/keycloak/data/import/foodmission-realm.dev.json
     depends_on:
       postgres:
         condition: service_healthy
-    command: start-dev
+    command: start-dev --import-realm
     healthcheck:
       test:
         ['CMD-SHELL', 'curl -f http://localhost:8080/health/ready || exit 1']

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "db:seed": "prisma db seed -- --environment development",
     "db:seed:prod": "prisma db seed -- --environment production",
     "db:translations": "ts-node scripts/seeds/seed-translations.ts",
+    "db:translations:prod": "node dist/scripts/seeds/seed-translations.js",
     "db:import:nevo-translations": "ts-node scripts/seeds/import-nevo-translations.ts",
     "db:seed:test": "ts-node scripts/dev/seed-test.ts",
     "db:seed:foods": "ts-node scripts/seeds/seed-food-products-only.ts",


### PR DESCRIPTION
# Pull Request

## Description

Hotfix because of

```
wait-for-db foodmission-pg-prod-rw.foodmission-prod.svc.cluster.local:5432 - accepting connections
wait-for-db Database is ready!
translations 
translations > foodmission-data-framework@0.0.1 db:translations
translations > ts-node scripts/seeds/seed-translations.ts
translations 
translations /app/node_modules/ts-node/src/index.ts:859
translations     return new TSError(diagnosticText, diagnosticCodes, diagnostics);
translations            ^
stream closed: EOF for foodmission-prod/foodmission-prod-db-translations-48tlq (wait-for-db)
translations TSError: ⨯ Unable to compile TypeScript:
translations scripts/seeds/prod/survey-translations.ts(4,51): error TS2307: Cannot find module '../../../src/i18n/constants' or its corresponding type declarations.
translations 
translations     at createTSError (/app/node_modules/ts-node/src/index.ts:859:12)
translations     at reportTSError (/app/node_modules/ts-node/src/index.ts:863:19)
translations     at getOutput (/app/node_modules/ts-node/src/index.ts:1077:36)
translations     at Object.compile (/app/node_modules/ts-node/src/index.ts:1433:41)
translations     at Module.m._compile (/app/node_modules/ts-node/src/index.ts:1617:30)
translations     at node:internal/modules/cjs/loader:2074:10
translations     at Object.require.extensions.<computed> [as .ts] (/app/node_modules/ts-node/src/index.ts:1621:12)
translations     at Module.load (node:internal/modules/cjs/loader:1656:32)
translations     at Module._load (node:internal/modules/cjs/loader:1448:12)
translations     at wrapModuleLoad (node:internal/modules/cjs/loader:261:19) {
translations   diagnosticCodes: [ 2307 ]
translations }
translations npm notice
translations npm notice New major version of npm available! 11.17.0 -> 12.0.2
translations npm notice Changelog: https://github.com/npm/cli/releases/tag/v12.0.2
translations npm notice To update run: npm install -g npm@12.0.2
translations npm notice
stream closed: EOF for foodmission-prod/foodmission-prod-db-translations-48tlq (translations)
                     
```

---

## 🐳 Docker Image Preview

**Available tags:**
- `ghcr.io/reedu-reengineering-education/foodmission-data-framework:pr-278`
- `ghcr.io/reedu-reengineering-education/foodmission-data-framework:sha-94061e7`

**Pull and test:**
```bash
docker pull ghcr.io/reedu-reengineering-education/foodmission-data-framework:pr-278
docker run -p 3000:3000 ghcr.io/reedu-reengineering-education/foodmission-data-framework:pr-278
```

**Multi-arch support:** ✅ AMD64 & ARM64
