### PR TITLE
fix: cors issue when registering new user through docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -50,7 +50,9 @@ MONGODB_OFF_URL="mongodb://localhost:27018/off?directConnection=true&serverSelec
 # MONGODB_OFF_URL="mongodb://<user>:<password>@mongodb-service.off-test.svc.cluster.local:27017/off?authSource=admin&serverSelectionTimeoutMS=5000"
 
 # CORS Configuration (optional)
-# CORS_ORIGINS="http://localhost:3000,http://localhost:3001"
+# Comma-separated browser Origins allowed to call the API. foodmission.eu / foodmission.dev
+# hosts (incl. api/test/staging/preview) are always allowed. List any other frontends here.
+# ALLOWED_ORIGINS="http://localhost:3000,https://app.example.com"
 
 # Monitoring Configuration (optional)
 # ENABLE_METRICS="true"

--- a/SECURITY_IMPLEMENTATION.md
+++ b/SECURITY_IMPLEMENTATION.md
@@ -44,7 +44,8 @@ This document summarizes the security features implemented for Task 17: Security
   - Removes X-Powered-By header
 
 - **CORS Configuration**
-  - Configurable allowed origins via environment variable
+  - Configurable allowed origins via `ALLOWED_ORIGINS` environment variable
+  - Always allows `*.foodmission.eu` / `*.foodmission.dev` (Swagger Try-it-out on API hosts)
   - Supports credentials
   - Proper preflight handling
   - Logs blocked CORS requests
@@ -54,6 +55,7 @@ This document summarizes the security features implemented for Task 17: Security
 - **Environment Validation Schema** (`src/security/config/environment.validation.ts`)
   - Uses Joi for comprehensive validation
   - Validates required variables (DATABASE_URL, etc.)
+
   <!-- - Enforces minimum security requirements (JWT_SECRET >= 32 chars) -->
   - Validates URLs, ports, and other formats
   - Different requirements for production vs development
@@ -102,7 +104,7 @@ This document summarizes the security features implemented for Task 17: Security
    - HSTS for HTTPS enforcement
 
 4. **CORS Protection**
-   - Configurable origin whitelist
+   - Configurable origin whitelist plus foodmission.eu/dev subdomain rule
    - Proper preflight handling
    - Credential support
    - Request logging
@@ -131,7 +133,7 @@ This document summarizes the security features implemented for Task 17: Security
 
 Security features are configured through environment variables:
 
-- `ALLOWED_ORIGINS`: Comma-separated list of allowed CORS origins
+- `ALLOWED_ORIGINS`: Comma-separated list of allowed CORS origins (trimmed). Origins under `foodmission.eu` / `foodmission.dev` are always allowed so Swagger Try-it-out works on api/test/staging/preview. Set this for any non-foodmission frontend Origins in each deploy environment.
 - `RATE_LIMIT_TTL`: Rate limit time window (default: 60000ms)
 - `RATE_LIMIT_MAX`: Maximum requests per window (default: 100)
 - `NODE_ENV`: Environment mode (affects security strictness)

--- a/src/security/security.service.spec.ts
+++ b/src/security/security.service.spec.ts
@@ -186,6 +186,49 @@ describe('SecurityService', () => {
       corsConfig.origin('https://api-staging.foodmission.eu', callback);
     });
 
+    it('should allow mixed-case foodmission origins', (done) => {
+      const corsConfig = service.getCorsConfiguration();
+      const callback = jest.fn((err, allow) => {
+        expect(err).toBeNull();
+        expect(allow).toBe(true);
+        done();
+      });
+
+      corsConfig.origin('https://API.FoodMission.EU', callback);
+    });
+
+    it('should match ALLOWED_ORIGINS case-insensitively', async () => {
+      const moduleWithCasedOrigin: TestingModule =
+        await Test.createTestingModule({
+          providers: [
+            SecurityService,
+            {
+              provide: ConfigService,
+              useValue: {
+                get: jest.fn((key: string) => {
+                  if (key === 'ALLOWED_ORIGINS') {
+                    return 'https://App.Example.COM';
+                  }
+                  return undefined;
+                }),
+              },
+            },
+          ],
+        }).compile();
+
+      const casedService =
+        moduleWithCasedOrigin.get<SecurityService>(SecurityService);
+      const corsConfig = casedService.getCorsConfiguration();
+
+      await new Promise<void>((resolve) => {
+        corsConfig.origin('https://app.example.com', (err, allow) => {
+          expect(err).toBeNull();
+          expect(allow).toBe(true);
+          resolve();
+        });
+      });
+    });
+
     it('should block unconfigured origins without throwing', (done) => {
       const corsConfig = service.getCorsConfiguration();
       const callback = jest.fn((err, allow) => {

--- a/src/security/security.service.spec.ts
+++ b/src/security/security.service.spec.ts
@@ -164,16 +164,37 @@ describe('SecurityService', () => {
       corsConfig.origin('http://localhost:3000', callback);
     });
 
-    it('should block unconfigured origins', (done) => {
+    it('should allow foodmission.eu API origin', (done) => {
       const corsConfig = service.getCorsConfiguration();
       const callback = jest.fn((err, allow) => {
-        expect(err).toBeInstanceOf(Error);
-        expect(err.message).toBe('Not allowed by CORS');
+        expect(err).toBeNull();
+        expect(allow).toBe(true);
+        done();
+      });
+
+      corsConfig.origin('https://api.foodmission.eu', callback);
+    });
+
+    it('should allow foodmission staging-like subdomains', (done) => {
+      const corsConfig = service.getCorsConfiguration();
+      const callback = jest.fn((err, allow) => {
+        expect(err).toBeNull();
+        expect(allow).toBe(true);
+        done();
+      });
+
+      corsConfig.origin('https://api-staging.foodmission.eu', callback);
+    });
+
+    it('should block unconfigured origins without throwing', (done) => {
+      const corsConfig = service.getCorsConfiguration();
+      const callback = jest.fn((err, allow) => {
+        expect(err).toBeNull();
         expect(allow).toBe(false);
         done();
       });
 
-      corsConfig.origin('http://malicious-site.com', callback);
+      corsConfig.origin('https://evil.example.com', callback);
     });
 
     it('should allow requests with no origin', (done) => {
@@ -185,6 +206,63 @@ describe('SecurityService', () => {
       });
 
       corsConfig.origin(undefined as any, callback);
+    });
+
+    it('should trim entries from ALLOWED_ORIGINS', async () => {
+      const moduleWithSpaces: TestingModule = await Test.createTestingModule({
+        providers: [
+          SecurityService,
+          {
+            provide: ConfigService,
+            useValue: {
+              get: jest.fn((key: string) => {
+                if (key === 'ALLOWED_ORIGINS') {
+                  return 'http://localhost:3000, https://app.example.com';
+                }
+                return undefined;
+              }),
+            },
+          },
+        ],
+      }).compile();
+
+      const spacedService =
+        moduleWithSpaces.get<SecurityService>(SecurityService);
+      const corsConfig = spacedService.getCorsConfiguration();
+
+      await new Promise<void>((resolve) => {
+        corsConfig.origin('https://app.example.com', (err, allow) => {
+          expect(err).toBeNull();
+          expect(allow).toBe(true);
+          resolve();
+        });
+      });
+    });
+
+    it('should use defaults including foodmission.eu when ALLOWED_ORIGINS is unset', async () => {
+      const moduleWithDefaults: TestingModule = await Test.createTestingModule({
+        providers: [
+          SecurityService,
+          {
+            provide: ConfigService,
+            useValue: {
+              get: jest.fn(() => undefined),
+            },
+          },
+        ],
+      }).compile();
+
+      const defaultService =
+        moduleWithDefaults.get<SecurityService>(SecurityService);
+      const corsConfig = defaultService.getCorsConfiguration();
+
+      await new Promise<void>((resolve) => {
+        corsConfig.origin('https://api.foodmission.eu', (err, allow) => {
+          expect(err).toBeNull();
+          expect(allow).toBe(true);
+          resolve();
+        });
+      });
     });
   });
 

--- a/src/security/security.service.ts
+++ b/src/security/security.service.ts
@@ -118,18 +118,42 @@ export class SecurityService {
   }
 
   /**
+   * Origins under foodmission.eu / foodmission.dev (incl. api/test/staging/preview).
+   * Used so Swagger Try-it-out works on every deployed API host without listing each hostname.
+   */
+  private static readonly FOODMISSION_ORIGIN_PATTERN =
+    /^https:\/\/([a-z0-9-]+\.)*foodmission\.(eu|dev)(:\d+)?$/;
+
+  private isAllowedCorsOrigin(
+    origin: string,
+    allowedOrigins: string[],
+  ): boolean {
+    return (
+      allowedOrigins.includes(origin) ||
+      SecurityService.FOODMISSION_ORIGIN_PATTERN.test(origin)
+    );
+  }
+
+  /**
    * Get CORS configuration
    */
   getCorsConfiguration() {
-    const allowedOrigins = this.configService
-      .get('ALLOWED_ORIGINS')
-      ?.split(',') || [
-      'http://localhost:3000',
-      'http://localhost:3001',
-      'http://localhost:4000',
-      'https://foodmission.dev',
-      'https://api.foodmission.dev',
-    ];
+    const allowedOriginsConfig =
+      this.configService.get<string>('ALLOWED_ORIGINS');
+    const allowedOrigins = allowedOriginsConfig
+      ? allowedOriginsConfig
+          .split(',')
+          .map((origin) => origin.trim())
+          .filter(Boolean)
+      : [
+          'http://localhost:3000',
+          'http://localhost:3001',
+          'http://localhost:4000',
+          'https://foodmission.dev',
+          'https://api.foodmission.dev',
+          'https://foodmission.eu',
+          'https://api.foodmission.eu',
+        ];
 
     return {
       origin: (
@@ -139,11 +163,12 @@ export class SecurityService {
         // Allow requests with no origin (mobile apps, curl, etc.)
         if (!origin) return callback(null, true);
 
-        if (allowedOrigins.includes(origin)) {
+        if (this.isAllowedCorsOrigin(origin, allowedOrigins)) {
           callback(null, true);
         } else {
           this.logger.warn(`CORS blocked request from origin: ${origin}`);
-          callback(new Error('Not allowed by CORS'), false);
+          // Pass null error so GlobalExceptionFilter does not turn this into a 500
+          callback(null, false);
         }
       },
       methods: ['GET', 'POST', 'PUT', 'DELETE', 'PATCH', 'OPTIONS'],

--- a/src/security/security.service.ts
+++ b/src/security/security.service.ts
@@ -120,17 +120,23 @@ export class SecurityService {
   /**
    * Origins under foodmission.eu / foodmission.dev (incl. api/test/staging/preview).
    * Used so Swagger Try-it-out works on every deployed API host without listing each hostname.
+   * Case-insensitive: Origin host is case-insensitive per the URL spec.
    */
   private static readonly FOODMISSION_ORIGIN_PATTERN =
-    /^https:\/\/([a-z0-9-]+\.)*foodmission\.(eu|dev)(:\d+)?$/;
+    /^https:\/\/([a-z0-9-]+\.)*foodmission\.(eu|dev)(:\d+)?$/i;
+
+  private normalizeCorsOrigin(origin: string): string {
+    return origin.trim().toLowerCase();
+  }
 
   private isAllowedCorsOrigin(
     origin: string,
     allowedOrigins: string[],
   ): boolean {
+    const normalizedOrigin = this.normalizeCorsOrigin(origin);
     return (
-      allowedOrigins.includes(origin) ||
-      SecurityService.FOODMISSION_ORIGIN_PATTERN.test(origin)
+      allowedOrigins.includes(normalizedOrigin) ||
+      SecurityService.FOODMISSION_ORIGIN_PATTERN.test(normalizedOrigin)
     );
   }
 
@@ -143,7 +149,7 @@ export class SecurityService {
     const allowedOrigins = allowedOriginsConfig
       ? allowedOriginsConfig
           .split(',')
-          .map((origin) => origin.trim())
+          .map((origin) => this.normalizeCorsOrigin(origin))
           .filter(Boolean)
       : [
           'http://localhost:3000',


### PR DESCRIPTION
## Summary

- Fix global CORS allowlist so Swagger Try-it-out works on `api.foodmission.eu` and test/staging/preview hosts (not just `foodmission.dev`).
- Always allow `https://*.foodmission.(eu|dev)` origins (case-insensitive), trim `ALLOWED_ORIGINS`, and add `.eu` defaults.
- Reject disallowed origins with `callback(null, false)` instead of throwing, so CORS denials are not turned into 500s by `GlobalExceptionFilter`.
- Correct `.env.example` (`CORS_ORIGINS` → `ALLOWED_ORIGINS`) and document deploy notes in `SECURITY_IMPLEMENTATION.md`.

This is **not** register-specific — the same global CORS config applies to all endpoints.

## Test plan

Here is a deployed preview - https://pr-30.api.foodmission.eu/api/docs#/auth/register.

### Live CORS checks 

Allowed origin — expect 2xx and Access-Control-Allow-Origin: https://api.foodmission.eu:
```
curl -i -X OPTIONS "http://localhost:5000/api/v1/auth/register" \
  -H "Origin: https://api.foodmission.eu" \
  -H "Access-Control-Request-Method: POST" \
  -H "Access-Control-Request-Headers: content-type"
```

Denied origin — expect no Access-Control-Allow-Origin
```
curl -i -X OPTIONS "http://localhost:5000/api/v1/auth/register" \
  -H "Origin: https://evil.example.com" \
  -H "Access-Control-Request-Method: POST" \
  -H "Access-Control-Request-Headers: content-type"
```