### PR TITLE
feat: allow multiple surveys per user

### DIFF
--- a/prisma/migrations/20260810140000_survey_response_multi_attempt/migration.sql
+++ b/prisma/migrations/20260810140000_survey_response_multi_attempt/migration.sql
@@ -1,0 +1,14 @@
+-- AlterTable
+ALTER TABLE "survey_responses" ADD COLUMN "attemptNumber" INTEGER;
+
+-- Backfill existing rows as attempt 1
+UPDATE "survey_responses" SET "attemptNumber" = 1 WHERE "attemptNumber" IS NULL;
+
+-- Make NOT NULL
+ALTER TABLE "survey_responses" ALTER COLUMN "attemptNumber" SET NOT NULL;
+
+-- DropIndex
+DROP INDEX "survey_responses_userId_surveyId_key";
+
+-- CreateIndex
+CREATE UNIQUE INDEX "survey_responses_userId_surveyId_attemptNumber_key" ON "survey_responses"("userId", "surveyId", "attemptNumber");

--- a/prisma/models/surveys.prisma
+++ b/prisma/models/surveys.prisma
@@ -34,18 +34,19 @@ model Question {
 }
 
 model SurveyResponse {
-  id       String @id @default(uuid())
-  userId   String
-  surveyId String
-  
-  survey   Survey @relation(fields: [surveyId], references: [id], onDelete: Cascade)
+  id            String @id @default(uuid())
+  userId        String
+  surveyId      String
+  attemptNumber Int
+
+  survey Survey @relation(fields: [surveyId], references: [id], onDelete: Cascade)
 
   questionResponses QuestionResponse[]
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
-  @@unique([userId, surveyId])
+  @@unique([userId, surveyId, attemptNumber])
   @@index([userId])
   @@index([surveyId])
   @@map("survey_responses")

--- a/src/surveys/controllers/surveys.controller.spec.ts
+++ b/src/surveys/controllers/surveys.controller.spec.ts
@@ -52,6 +52,7 @@ describe('SurveysController', () => {
       deleteQuestion: jest.fn(),
       submitSurveyResponse: jest.fn(),
       getUserSurveyResponse: jest.fn(),
+      getUserSurveyResponsesForSurvey: jest.fn(),
       getUserSurveyResponses: jest.fn(),
     };
 
@@ -211,6 +212,7 @@ describe('SurveysController', () => {
         id: 'response-1',
         userId: 'user-1',
         surveyId: 'survey-1',
+        attemptNumber: 1,
         responses: [
           {
             id: 'qr-1',
@@ -247,6 +249,7 @@ describe('SurveysController', () => {
         id: 'response-1',
         userId: 'user-1',
         surveyId: 'survey-1',
+        attemptNumber: 2,
         responses: [],
         createdAt: new Date(),
         updatedAt: new Date(),
@@ -269,6 +272,46 @@ describe('SurveysController', () => {
     });
   });
 
+  describe('getUserSurveyResponsesForSurvey', () => {
+    it('should get all attempts for a survey', async () => {
+      const mockResponses = [
+        {
+          id: 'response-1',
+          userId: 'user-1',
+          surveyId: 'survey-1',
+          attemptNumber: 1,
+          responses: [],
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+        {
+          id: 'response-2',
+          userId: 'user-1',
+          surveyId: 'survey-1',
+          attemptNumber: 2,
+          responses: [],
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+      ];
+
+      service.getUserSurveyResponsesForSurvey.mockResolvedValue(mockResponses);
+
+      const result = await controller.getUserSurveyResponsesForSurvey(
+        'survey-1',
+        mockUserId,
+        {},
+      );
+
+      expect(result).toEqual(mockResponses);
+      expect(service.getUserSurveyResponsesForSurvey).toHaveBeenCalledWith(
+        'user-1',
+        'survey-1',
+        undefined,
+      );
+    });
+  });
+
   describe('getUserSurveyResponses', () => {
     it('should get all user survey responses', async () => {
       const mockResponses = [
@@ -276,6 +319,7 @@ describe('SurveysController', () => {
           id: 'response-1',
           userId: 'user-1',
           surveyId: 'survey-1',
+          attemptNumber: 1,
           responses: [],
           createdAt: new Date(),
           updatedAt: new Date(),

--- a/src/surveys/controllers/surveys.controller.ts
+++ b/src/surveys/controllers/surveys.controller.ts
@@ -19,7 +19,6 @@ import {
   ApiParam,
   ApiQuery,
   ApiBody,
-  ApiConflictResponse,
   ApiBadRequestResponse,
   ApiNotFoundResponse,
 } from '@nestjs/swagger';
@@ -135,7 +134,7 @@ export class SurveysController {
   @ApiOperation({
     summary: 'Submit survey responses',
     description:
-      'Submit user responses to a survey. Each response must contain a valid question ID and a Likert value (1-5). A user can only submit one response per survey.',
+      'Submit user responses to a survey. Each response must contain a valid question ID and a Likert value (1-5). Users may submit the same survey multiple times; each submit creates a new attempt.',
   })
   @ApiBody({ type: SubmitSurveyResponseDto })
   @ApiResponse({
@@ -148,9 +147,6 @@ export class SurveysController {
       'Invalid request - missing questions, invalid question ID, out-of-range value, or validation errors',
   })
   @ApiNotFoundResponse({ description: 'Survey not found' })
-  @ApiConflictResponse({
-    description: 'User has already submitted responses for this survey',
-  })
   async submitSurveyResponse(
     @Param('id') surveyId: string,
     @Body() dto: SubmitSurveyResponseDto,
@@ -161,13 +157,45 @@ export class SurveysController {
     });
   }
 
+  @Get(':id/responses/me/all')
+  @ApiBearerAuth('JWT-auth')
+  @ApiParam({ name: 'id', description: 'Survey ID' })
+  @ApiOperation({
+    summary: "Get all of the user's attempts for a survey",
+    description:
+      'Retrieve every survey response attempt submitted by the current user for this survey, oldest first.',
+  })
+  @ApiQuery({
+    name: 'lang',
+    required: false,
+    enum: SUPPORTED_LOCALES,
+    description: `Optional locale for translated question texts. Defaults to ${DEFAULT_LOCALE}.`,
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'User survey response attempts retrieved successfully',
+    type: [SurveyResponseDto],
+  })
+  @ApiNotFoundResponse({ description: 'Survey not found' })
+  async getUserSurveyResponsesForSurvey(
+    @Param('id') surveyId: string,
+    @CurrentUser('id') userId: string,
+    @Query() query: SurveyQueryDto,
+  ): Promise<SurveyResponseDto[]> {
+    return this.surveysService.getUserSurveyResponsesForSurvey(
+      userId,
+      surveyId,
+      query.lang,
+    );
+  }
+
   @Get(':id/responses/me')
   @ApiBearerAuth('JWT-auth')
   @ApiParam({ name: 'id', description: 'Survey ID' })
   @ApiOperation({
-    summary: "Get user's survey response",
+    summary: "Get user's latest survey response",
     description:
-      "Retrieve the current user's responses to a specific survey if they have responded.",
+      "Retrieve the current user's latest attempt for a specific survey if they have responded.",
   })
   @ApiQuery({
     name: 'lang',
@@ -199,7 +227,8 @@ export class SurveysController {
   @ApiBearerAuth('JWT-auth')
   @ApiOperation({
     summary: "Get all user's survey responses",
-    description: 'Retrieve all survey responses submitted by the current user.',
+    description:
+      'Retrieve all survey response attempts submitted by the current user (may include multiple attempts per survey).',
   })
   @ApiQuery({
     name: 'lang',

--- a/src/surveys/dto/survey.dto.ts
+++ b/src/surveys/dto/survey.dto.ts
@@ -102,6 +102,8 @@ export class SurveyResponseDto {
   id: string;
   userId: string;
   surveyId: string;
+  /** 1-based attempt counter; each submit creates a new attempt. */
+  attemptNumber: number;
   responses: QuestionResponseDto[];
   createdAt: Date;
   updatedAt: Date;

--- a/src/surveys/repositories/surveys.repository.spec.ts
+++ b/src/surveys/repositories/surveys.repository.spec.ts
@@ -1,0 +1,102 @@
+import { Prisma } from '@prisma/client';
+import { SurveysRepository } from './surveys.repository';
+import { PrismaService } from '../../database/prisma.service';
+import { SubmitSurveyResponseDto } from '../dto/survey.dto';
+
+describe('SurveysRepository', () => {
+  let repository: SurveysRepository;
+  let prisma: {
+    $transaction: jest.Mock;
+    surveyResponse: {
+      findFirst: jest.Mock;
+      create: jest.Mock;
+    };
+  };
+
+  const submitDto: SubmitSurveyResponseDto = {
+    responses: [{ questionId: 'q-1', value: 4 }],
+  };
+
+  const createdResponse = {
+    id: 'response-2',
+    userId: 'user-1',
+    surveyId: 'survey-1',
+    attemptNumber: 2,
+    questionResponses: [],
+  };
+
+  beforeEach(() => {
+    prisma = {
+      $transaction: jest.fn(),
+      surveyResponse: {
+        findFirst: jest.fn(),
+        create: jest.fn(),
+      },
+    };
+    repository = new SurveysRepository(prisma as unknown as PrismaService);
+  });
+
+  describe('submitSurveyResponse', () => {
+    it('creates a new attempt with the next attemptNumber', async () => {
+      prisma.surveyResponse.findFirst.mockResolvedValue({ attemptNumber: 1 });
+      prisma.surveyResponse.create.mockResolvedValue(createdResponse);
+      prisma.$transaction.mockImplementation(async (cb) => cb(prisma));
+
+      const result = await repository.submitSurveyResponse(
+        'user-1',
+        'survey-1',
+        submitDto,
+      );
+
+      expect(result).toEqual(createdResponse);
+      expect(prisma.surveyResponse.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            userId: 'user-1',
+            surveyId: 'survey-1',
+            attemptNumber: 2,
+          }),
+        }),
+      );
+    });
+
+    it('retries on P2002 unique-constraint race and succeeds', async () => {
+      const uniqueError = new Prisma.PrismaClientKnownRequestError(
+        'Unique constraint failed',
+        { code: 'P2002', clientVersion: '6.0.0' },
+      );
+
+      prisma.$transaction
+        .mockRejectedValueOnce(uniqueError)
+        .mockImplementationOnce(async (cb) => {
+          prisma.surveyResponse.findFirst.mockResolvedValue({
+            attemptNumber: 1,
+          });
+          prisma.surveyResponse.create.mockResolvedValue(createdResponse);
+          return cb(prisma);
+        });
+
+      const result = await repository.submitSurveyResponse(
+        'user-1',
+        'survey-1',
+        submitDto,
+      );
+
+      expect(result).toEqual(createdResponse);
+      expect(prisma.$transaction).toHaveBeenCalledTimes(2);
+    });
+
+    it('rethrows after exhausting P2002 retries', async () => {
+      const uniqueError = new Prisma.PrismaClientKnownRequestError(
+        'Unique constraint failed',
+        { code: 'P2002', clientVersion: '6.0.0' },
+      );
+      prisma.$transaction.mockRejectedValue(uniqueError);
+
+      await expect(
+        repository.submitSurveyResponse('user-1', 'survey-1', submitDto),
+      ).rejects.toBe(uniqueError);
+      expect(prisma.$transaction).toHaveBeenCalledTimes(3);
+    });
+  });
+});

--- a/src/surveys/repositories/surveys.repository.spec.ts
+++ b/src/surveys/repositories/surveys.repository.spec.ts
@@ -40,7 +40,7 @@ describe('SurveysRepository', () => {
     it('creates a new attempt with the next attemptNumber', async () => {
       prisma.surveyResponse.findFirst.mockResolvedValue({ attemptNumber: 1 });
       prisma.surveyResponse.create.mockResolvedValue(createdResponse);
-      prisma.$transaction.mockImplementation(async (cb) => cb(prisma));
+      prisma.$transaction.mockImplementation(async (cb) => await cb(prisma));
 
       const result = await repository.submitSurveyResponse(
         'user-1',
@@ -73,7 +73,7 @@ describe('SurveysRepository', () => {
             attemptNumber: 1,
           });
           prisma.surveyResponse.create.mockResolvedValue(createdResponse);
-          return cb(prisma);
+          return await cb(prisma);
         });
 
       const result = await repository.submitSurveyResponse(

--- a/src/surveys/repositories/surveys.repository.ts
+++ b/src/surveys/repositories/surveys.repository.ts
@@ -143,6 +143,31 @@ export class SurveysRepository {
     surveyId: string,
     data: SubmitSurveyResponseDto,
   ) {
+    // Concurrent submits can both read the same latest attemptNumber; retry on
+    // the unique-constraint race so the second caller gets the next number.
+    const maxAttempts = 3;
+    for (let attempt = 0; attempt < maxAttempts; attempt++) {
+      try {
+        return await this.createSurveyResponseAttempt(userId, surveyId, data);
+      } catch (error) {
+        const isUniqueViolation =
+          error instanceof Prisma.PrismaClientKnownRequestError &&
+          error.code === 'P2002';
+        if (!isUniqueViolation || attempt === maxAttempts - 1) {
+          throw error;
+        }
+      }
+    }
+
+    // Unreachable: loop always returns or throws.
+    throw new Error('Failed to submit survey response');
+  }
+
+  private createSurveyResponseAttempt(
+    userId: string,
+    surveyId: string,
+    data: SubmitSurveyResponseDto,
+  ) {
     return this.prisma.$transaction(async (tx) => {
       const latest = await tx.surveyResponse.findFirst({
         where: { userId, surveyId },

--- a/src/surveys/repositories/surveys.repository.ts
+++ b/src/surveys/repositories/surveys.repository.ts
@@ -1,10 +1,26 @@
 import { Injectable } from '@nestjs/common';
+import { Prisma } from '@prisma/client';
 import { PrismaService } from '../../database/prisma.service';
 import {
   CreateSurveyDto,
   UpdateSurveyDto,
   SubmitSurveyResponseDto,
 } from '../dto/survey.dto';
+
+const surveyResponseInclude = {
+  questionResponses: {
+    include: {
+      question: true,
+    },
+  },
+  survey: {
+    include: {
+      questions: {
+        orderBy: { order: 'asc' as const },
+      },
+    },
+  },
+} satisfies Prisma.SurveyResponseInclude;
 
 @Injectable()
 export class SurveysRepository {
@@ -103,25 +119,22 @@ export class SurveysRepository {
   }
 
   // Survey Response Operations
+
+  /** Latest attempt for this user + survey, or null if none. */
   async getSurveyResponse(userId: string, surveyId: string) {
-    return this.prisma.surveyResponse.findUnique({
-      where: {
-        userId_surveyId: { userId, surveyId },
-      },
-      include: {
-        questionResponses: {
-          include: {
-            question: true,
-          },
-        },
-        survey: {
-          include: {
-            questions: {
-              orderBy: { order: 'asc' },
-            },
-          },
-        },
-      },
+    return this.prisma.surveyResponse.findFirst({
+      where: { userId, surveyId },
+      orderBy: { attemptNumber: 'desc' },
+      include: surveyResponseInclude,
+    });
+  }
+
+  /** All attempts for this user + survey, oldest first. */
+  async getUserSurveyResponsesForSurvey(userId: string, surveyId: string) {
+    return this.prisma.surveyResponse.findMany({
+      where: { userId, surveyId },
+      orderBy: { attemptNumber: 'asc' },
+      include: surveyResponseInclude,
     });
   }
 
@@ -130,54 +143,36 @@ export class SurveysRepository {
     surveyId: string,
     data: SubmitSurveyResponseDto,
   ) {
-    // Create or update survey response
-    const surveyResponse = await this.prisma.surveyResponse.upsert({
-      where: {
-        userId_surveyId: { userId, surveyId },
-      },
-      update: { updatedAt: new Date() },
-      create: {
-        userId,
-        surveyId,
-      },
-    });
+    return this.prisma.$transaction(async (tx) => {
+      const latest = await tx.surveyResponse.findFirst({
+        where: { userId, surveyId },
+        orderBy: { attemptNumber: 'desc' },
+        select: { attemptNumber: true },
+      });
+      const attemptNumber = (latest?.attemptNumber ?? 0) + 1;
 
-    // Delete old question responses
-    await this.prisma.questionResponse.deleteMany({
-      where: { surveyResponseId: surveyResponse.id },
+      return tx.surveyResponse.create({
+        data: {
+          userId,
+          surveyId,
+          attemptNumber,
+          questionResponses: {
+            create: data.responses.map((response) => ({
+              questionId: response.questionId,
+              value: response.value,
+            })),
+          },
+        },
+        include: surveyResponseInclude,
+      });
     });
-
-    // Create new question responses
-    await this.prisma.questionResponse.createMany({
-      data: data.responses.map((response) => ({
-        surveyResponseId: surveyResponse.id,
-        questionId: response.questionId,
-        value: response.value,
-      })),
-    });
-
-    // Return updated response with relations
-    return this.getSurveyResponse(userId, surveyId);
   }
 
   async getUserSurveyResponses(userId: string) {
     return this.prisma.surveyResponse.findMany({
       where: { userId },
-      include: {
-        survey: {
-          include: {
-            questions: {
-              orderBy: { order: 'asc' },
-            },
-          },
-        },
-        questionResponses: {
-          include: {
-            question: true,
-          },
-        },
-      },
-      orderBy: { updatedAt: 'desc' },
+      include: surveyResponseInclude,
+      orderBy: [{ surveyId: 'asc' }, { attemptNumber: 'desc' }],
     });
   }
 }

--- a/src/surveys/services/surveys.service.spec.ts
+++ b/src/surveys/services/surveys.service.spec.ts
@@ -2,7 +2,6 @@ import { Test, TestingModule } from '@nestjs/testing';
 import {
   BadRequestException,
   NotFoundException,
-  ConflictException,
 } from '@nestjs/common';
 import { SurveysService } from './surveys.service';
 import { SurveysRepository } from '../repositories/surveys.repository';
@@ -77,6 +76,7 @@ describe('SurveysService', () => {
             deleteQuestion: jest.fn(),
             getSurveyResponse: jest.fn(),
             getUserSurveyResponses: jest.fn(),
+            getUserSurveyResponsesForSurvey: jest.fn(),
             submitSurveyResponse: jest.fn(),
           },
         },
@@ -357,6 +357,7 @@ describe('SurveysService', () => {
         id: 'response-1',
         userId: 'user-1',
         surveyId: 'survey-1',
+        attemptNumber: 1,
         questionResponses: [
           {
             id: 'qr-1',
@@ -374,7 +375,6 @@ describe('SurveysService', () => {
       };
 
       repository.getSurveyById.mockResolvedValue(mockSurvey);
-      repository.getSurveyResponse.mockResolvedValueOnce(null); // No existing response
       repository.submitSurveyResponse.mockResolvedValue(mockResponseData);
 
       const result = await service.submitSurveyResponse(
@@ -384,39 +384,62 @@ describe('SurveysService', () => {
       );
 
       expect(result).toBeDefined();
+      expect(result.attemptNumber).toBe(1);
       expect(repository.submitSurveyResponse).toHaveBeenCalledWith(
         'user-1',
         'survey-1',
         submitDto,
       );
+      expect(repository.getSurveyResponse).not.toHaveBeenCalled();
     });
 
-    it('should throw ConflictException when user already responded to survey', async () => {
+    it('should allow submitting the same survey again as a new attempt', async () => {
       const submitDto: SubmitSurveyResponseDto = {
         responses: [
           {
             questionId: 'q-1',
-            value: 3,
+            value: 2,
           },
         ],
       };
 
-      const existingResponse = {
-        id: 'existing-response',
+      const mockResponseData = {
+        id: 'response-2',
         userId: 'user-1',
         surveyId: 'survey-1',
-        questionResponses: [],
+        attemptNumber: 2,
+        questionResponses: [
+          {
+            id: 'qr-2',
+            questionId: 'q-1',
+            value: 2,
+            surveyResponseId: 'response-2',
+            question: mockQuestion,
+            createdAt: new Date(),
+            updatedAt: new Date(),
+          },
+        ],
         survey: mockSurvey,
         createdAt: new Date(),
         updatedAt: new Date(),
       };
 
       repository.getSurveyById.mockResolvedValue(mockSurvey);
-      repository.getSurveyResponse.mockResolvedValue(existingResponse);
+      repository.submitSurveyResponse.mockResolvedValue(mockResponseData);
 
-      await expect(
-        service.submitSurveyResponse('user-1', 'survey-1', submitDto),
-      ).rejects.toThrow(ConflictException);
+      const result = await service.submitSurveyResponse(
+        'user-1',
+        'survey-1',
+        submitDto,
+      );
+
+      expect(result.id).toBe('response-2');
+      expect(result.attemptNumber).toBe(2);
+      expect(repository.submitSurveyResponse).toHaveBeenCalledWith(
+        'user-1',
+        'survey-1',
+        submitDto,
+      );
     });
 
     it('should throw BadRequestException when response contains invalid question', async () => {
@@ -430,7 +453,6 @@ describe('SurveysService', () => {
       };
 
       repository.getSurveyById.mockResolvedValue(mockSurvey);
-      repository.getSurveyResponse.mockResolvedValue(null);
 
       await expect(
         service.submitSurveyResponse('user-1', 'survey-1', submitDto),
@@ -439,11 +461,12 @@ describe('SurveysService', () => {
   });
 
   describe('getUserSurveyResponse', () => {
-    it('should get user survey response', async () => {
+    it('should get the latest user survey response', async () => {
       const mockResponse = {
-        id: 'response-1',
+        id: 'response-2',
         userId: 'user-1',
         surveyId: 'survey-1',
+        attemptNumber: 2,
         questionResponses: [],
         survey: mockSurvey,
         createdAt: new Date(),
@@ -455,7 +478,8 @@ describe('SurveysService', () => {
       const result = await service.getUserSurveyResponse('user-1', 'survey-1');
 
       expect(result).toBeDefined();
-      expect(result.id).toBe('response-1');
+      expect(result.id).toBe('response-2');
+      expect(result.attemptNumber).toBe(2);
     });
 
     it('should throw NotFoundException when response not found', async () => {
@@ -463,6 +487,59 @@ describe('SurveysService', () => {
 
       await expect(
         service.getUserSurveyResponse('user-1', 'survey-1'),
+      ).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('getUserSurveyResponsesForSurvey', () => {
+    it('should return all attempts for a survey oldest first', async () => {
+      const mockResponses = [
+        {
+          id: 'response-1',
+          userId: 'user-1',
+          surveyId: 'survey-1',
+          attemptNumber: 1,
+          questionResponses: [],
+          survey: mockSurvey,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+        {
+          id: 'response-2',
+          userId: 'user-1',
+          surveyId: 'survey-1',
+          attemptNumber: 2,
+          questionResponses: [],
+          survey: mockSurvey,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+      ];
+
+      repository.getSurveyById.mockResolvedValue(mockSurvey);
+      repository.getUserSurveyResponsesForSurvey.mockResolvedValue(
+        mockResponses,
+      );
+
+      const result = await service.getUserSurveyResponsesForSurvey(
+        'user-1',
+        'survey-1',
+      );
+
+      expect(result).toHaveLength(2);
+      expect(result[0].attemptNumber).toBe(1);
+      expect(result[1].attemptNumber).toBe(2);
+      expect(repository.getUserSurveyResponsesForSurvey).toHaveBeenCalledWith(
+        'user-1',
+        'survey-1',
+      );
+    });
+
+    it('should throw NotFoundException when survey does not exist', async () => {
+      repository.getSurveyById.mockResolvedValue(null);
+
+      await expect(
+        service.getUserSurveyResponsesForSurvey('user-1', 'missing'),
       ).rejects.toThrow(NotFoundException);
     });
   });

--- a/src/surveys/services/surveys.service.ts
+++ b/src/surveys/services/surveys.service.ts
@@ -2,7 +2,6 @@ import {
   Injectable,
   NotFoundException,
   BadRequestException,
-  ConflictException,
 } from '@nestjs/common';
 import { SurveysRepository } from '../repositories/surveys.repository';
 import {
@@ -338,24 +337,11 @@ export class SurveysService {
     surveyId: string,
     data: SubmitSurveyResponseDto,
   ): Promise<SurveyResponseDto> {
-    // Validate survey exists
     const survey = await this.surveysRepository.getSurveyById(surveyId);
     if (!survey) {
       throw new NotFoundException(`Survey with id ${surveyId} not found`);
     }
 
-    // Check if user already responded to this survey
-    const existingResponse = await this.surveysRepository.getSurveyResponse(
-      userId,
-      surveyId,
-    );
-    if (existingResponse) {
-      throw new ConflictException(
-        `User has already responded to survey ${surveyId}`,
-      );
-    }
-
-    // Validate all questions belong to the survey
     const questionIds = new Set(survey.questions.map((q) => q.id));
     for (const response of data.responses) {
       if (!questionIds.has(response.questionId)) {
@@ -365,19 +351,15 @@ export class SurveysService {
       }
     }
 
-    // Prepare data for repository
-    const submitData: SubmitSurveyResponseDto = {
-      responses: data.responses,
-    };
-
     const result = await this.surveysRepository.submitSurveyResponse(
       userId,
       surveyId,
-      submitData,
+      { responses: data.responses },
     );
     return this.mapSurveyResponseToDto(result);
   }
 
+  /** Latest attempt for this user + survey. */
   async getUserSurveyResponse(
     userId: string,
     surveyId: string,
@@ -394,6 +376,26 @@ export class SurveysService {
     }
     const [localized] = await this.localizeSurveyResponses([response], lang);
     return this.mapSurveyResponseToDto(localized);
+  }
+
+  /** All attempts for this user + survey, oldest first. */
+  async getUserSurveyResponsesForSurvey(
+    userId: string,
+    surveyId: string,
+    lang?: string,
+  ): Promise<SurveyResponseDto[]> {
+    const survey = await this.surveysRepository.getSurveyById(surveyId);
+    if (!survey) {
+      throw new NotFoundException(`Survey with id ${surveyId} not found`);
+    }
+
+    const responses =
+      await this.surveysRepository.getUserSurveyResponsesForSurvey(
+        userId,
+        surveyId,
+      );
+    const localized = await this.localizeSurveyResponses(responses, lang);
+    return localized.map((r) => this.mapSurveyResponseToDto(r));
   }
 
   async getUserSurveyResponses(userId: string, lang?: string) {


### PR DESCRIPTION
## Summary
- Users can submit the same survey more than once; each submit creates an immutable attempt with an incremented `attemptNumber` (no overwrite, no 409).
- Schema uniqueness is now `(userId, surveyId, attemptNumber)`; existing responses are backfilled as attempt `1`.
- `GET /surveys/:id/responses/me` returns the latest attempt; new `GET /surveys/:id/responses/me/all` returns full history for that survey.

## Test plan
- [ ] Apply migration `20260810140000_survey_response_multi_attempt`
- [ ] Submit a survey once → `201` with `attemptNumber: 1`
- [ ] Submit the same survey again → `201` with `attemptNumber: 2` (not 409)
- [ ] `GET /surveys/:id/responses/me` returns the second attempt
- [ ] `GET /surveys/:id/responses/me/all` returns both attempts, oldest first
- [ ] `GET /surveys/responses/user/all` includes multiple rows for the same survey
- [ ] Unit tests: `npx jest src/surveys`

---

## 🐳 Docker Image Preview

**Available tags:**
- `ghcr.io/reedu-reengineering-education/foodmission-data-framework:pr-291`
- `ghcr.io/reedu-reengineering-education/foodmission-data-framework:sha-bf6235f`

**Pull and test:**
```bash
docker pull ghcr.io/reedu-reengineering-education/foodmission-data-framework:pr-291
docker run -p 3000:3000 ghcr.io/reedu-reengineering-education/foodmission-data-framework:pr-291
```

**Multi-arch support:** ✅ AMD64 & ARM64
