### PR TITLE
fix: add only admin tags to docs, remove all previous admin tags

### DIFF
--- a/src/challenges/controllers/challenges.controller.ts
+++ b/src/challenges/controllers/challenges.controller.ts
@@ -99,7 +99,7 @@ export class ChallengesController {
   @Roles('admin')
   @ApiBearerAuth('JWT-auth')
   @ApiOperation({
-    summary: 'List all challenge progress rows (admin, paginated)',
+    summary: 'List all challenge progress rows (paginated)',
     description:
       'Returns paginated challenge progress for all users. Use instead of embedded progress on challenge list.',
   })

--- a/src/docs/swagger.document.ts
+++ b/src/docs/swagger.document.ts
@@ -1,4 +1,5 @@
-import { INestApplication } from '@nestjs/common';
+import { INestApplication, RequestMethod } from '@nestjs/common';
+import { METHOD_METADATA, PATH_METADATA } from '@nestjs/common/constants';
 import { SwaggerModule } from '@nestjs/swagger';
 import { createSwaggerConfig, getSwaggerMetadata } from './swagger.config';
 
@@ -12,9 +13,175 @@ const documentOptions = {
 
 export type OpenApiDocument = ReturnType<typeof createOpenApiDocument>;
 
+const ROLES_METADATA_KEY = 'roles';
+
+const HTTP_METHOD_BY_REQUEST_METHOD: Record<RequestMethod, string> = {
+  [RequestMethod.GET]: 'get',
+  [RequestMethod.POST]: 'post',
+  [RequestMethod.PUT]: 'put',
+  [RequestMethod.DELETE]: 'delete',
+  [RequestMethod.PATCH]: 'patch',
+  [RequestMethod.ALL]: 'get',
+  [RequestMethod.OPTIONS]: 'options',
+  [RequestMethod.HEAD]: 'head',
+  [RequestMethod.SEARCH]: 'get',
+  [RequestMethod.MKCOL]: 'post',
+  [RequestMethod.COPY]: 'post',
+  [RequestMethod.MOVE]: 'post',
+  [RequestMethod.PROPFIND]: 'get',
+  [RequestMethod.PROPPATCH]: 'patch',
+  [RequestMethod.LOCK]: 'post',
+  [RequestMethod.UNLOCK]: 'post',
+};
+
+function normalizePathFragments(pathMeta: unknown): string[] {
+  if (Array.isArray(pathMeta)) {
+    return pathMeta.map((p) => String(p ?? ''));
+  }
+  if (pathMeta === undefined || pathMeta === null) {
+    return [''];
+  }
+  return [String(pathMeta)];
+}
+
+function normalizeJoinedPath(...parts: string[]): string {
+  const cleaned = parts
+    .map((p) => p.trim())
+    .filter((p) => p.length > 0)
+    .map((p) => p.replace(/^\/+|\/+$/g, ''))
+    .map((p) => p.replace(/:([A-Za-z0-9_]+)/g, '{$1}'))
+    .filter((p) => p.length > 0);
+
+  if (cleaned.length === 0) {
+    return '/';
+  }
+
+  return `/${cleaned.join('/')}`;
+}
+
+function isAdminOnly(roles: string[] | undefined): boolean {
+  if (!roles || roles.length !== 1) {
+    return false;
+  }
+  return roles[0] === 'admin';
+}
+
+function hasAdminOnlySummaryLabel(summary: string): boolean {
+  return (
+    /\badmin[-\s]?only\b/i.test(summary) || /\bonly\s+admin\b/i.test(summary)
+  );
+}
+
+function appendAdminOnlyLabel(operation: {
+  summary?: string;
+  description?: string;
+}): void {
+  if (operation.summary && !hasAdminOnlySummaryLabel(operation.summary)) {
+    operation.summary = `${operation.summary} (Admin only)`;
+  }
+
+  const note = 'Access: Admin only.';
+  if (!operation.description) {
+    operation.description = note;
+    return;
+  }
+
+  if (!operation.description.includes(note)) {
+    operation.description = `${operation.description}\n\n${note}`;
+  }
+}
+
+function annotateAdminOnlyOperations(
+  app: INestApplication,
+  document: OpenApiDocument,
+): void {
+  const container = (
+    app as unknown as {
+      container?: { getModules?: () => Map<unknown, unknown> };
+    }
+  ).container;
+  const modulesMap = container?.getModules?.();
+  if (!modulesMap) {
+    return;
+  }
+
+  for (const moduleRef of modulesMap.values() as Iterable<{
+    controllers?: Map<unknown, { instance?: object }>;
+  }>) {
+    const controllers = moduleRef.controllers;
+    if (!controllers) continue;
+
+    for (const wrapper of controllers.values()) {
+      const instance = wrapper.instance;
+      if (!instance) continue;
+
+      const controllerClass = (instance as { constructor: object }).constructor;
+      const controllerPaths = normalizePathFragments(
+        Reflect.getMetadata(PATH_METADATA, controllerClass),
+      );
+      const controllerRoles = Reflect.getMetadata(
+        ROLES_METADATA_KEY,
+        controllerClass,
+      ) as string[] | undefined;
+
+      const prototype = Object.getPrototypeOf(instance) as Record<
+        string,
+        unknown
+      >;
+      for (const methodName of Object.getOwnPropertyNames(prototype)) {
+        if (methodName === 'constructor') continue;
+
+        const handler = prototype[methodName];
+        if (typeof handler !== 'function') continue;
+
+        const requestMethod = Reflect.getMetadata(METHOD_METADATA, handler) as
+          RequestMethod | undefined;
+        if (requestMethod === undefined) continue;
+
+        const httpMethod = HTTP_METHOD_BY_REQUEST_METHOD[requestMethod];
+        if (!httpMethod) continue;
+
+        const methodPaths = normalizePathFragments(
+          Reflect.getMetadata(PATH_METADATA, handler),
+        );
+        const methodRoles = Reflect.getMetadata(ROLES_METADATA_KEY, handler) as
+          string[] | undefined;
+        const effectiveRoles = methodRoles ?? controllerRoles;
+        if (!isAdminOnly(effectiveRoles)) continue;
+
+        for (const ctrlPath of controllerPaths) {
+          for (const methodPath of methodPaths) {
+            const candidates = [
+              normalizeJoinedPath('api/v1', ctrlPath, methodPath),
+              normalizeJoinedPath(ctrlPath, methodPath),
+            ];
+
+            for (const pathKey of candidates) {
+              const pathItem = (
+                document.paths as
+                  | Record<
+                      string,
+                      Record<string, { summary?: string; description?: string }>
+                    >
+                  | undefined
+              )?.[pathKey];
+              const operation = pathItem?.[httpMethod];
+              if (!operation) continue;
+              appendAdminOnlyLabel(operation);
+              break;
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
 export function createOpenApiDocument(app: INestApplication) {
   const config = createSwaggerConfig();
-  return SwaggerModule.createDocument(app, config, documentOptions);
+  const document = SwaggerModule.createDocument(app, config, documentOptions);
+  annotateAdminOnlyOperations(app, document);
+  return document;
 }
 
 function setupOpenApiDocs(

--- a/src/docs/swagger.document.ts
+++ b/src/docs/swagger.document.ts
@@ -41,6 +41,9 @@ function normalizePathFragments(pathMeta: unknown): string[] {
   if (pathMeta === undefined || pathMeta === null) {
     return [''];
   }
+  if (typeof pathMeta !== 'string' && typeof pathMeta !== 'number') {
+    return [''];
+  }
   return [String(pathMeta)];
 }
 

--- a/src/learning/controllers/quests.controller.ts
+++ b/src/learning/controllers/quests.controller.ts
@@ -46,7 +46,7 @@ export class QuestsController {
   @ApiBearerAuth('JWT-auth')
   @HttpCode(HttpStatus.CREATED)
   @ApiOperation({
-    summary: 'Create a quest (admin)',
+    summary: 'Create a quest',
     description:
       'Creates a quest with nested items. Item contentCode values must exist for the given contentType. Unique on code.',
   })
@@ -96,7 +96,7 @@ export class QuestsController {
   @Roles('admin')
   @ApiBearerAuth('JWT-auth')
   @ApiOperation({
-    summary: 'List all quest progress rows (admin, paginated)',
+    summary: 'List all quest progress rows (paginated)',
     description:
       'Returns paginated quest progress for all users. Supports lang for translated quest titles.',
   })

--- a/src/learning/controllers/quizzes.controller.ts
+++ b/src/learning/controllers/quizzes.controller.ts
@@ -71,7 +71,7 @@ export class QuizzesController {
   @Roles('admin')
   @ApiBearerAuth('JWT-auth')
   @ApiOperation({
-    summary: 'List all quiz progress rows (admin, paginated)',
+    summary: 'List all quiz progress rows (paginated)',
     description:
       'Returns paginated quiz progress for all users. Supports lang for translated questions.',
   })

--- a/src/missions/controllers/missions.controller.ts
+++ b/src/missions/controllers/missions.controller.ts
@@ -107,7 +107,7 @@ export class MissionsController {
   @Roles('admin')
   @ApiBearerAuth('JWT-auth')
   @ApiOperation({
-    summary: 'List all mission progress rows (admin, paginated)',
+    summary: 'List all mission progress rows (paginated)',
     description:
       'Returns paginated mission progress for all users. Use instead of embedded progress on mission list.',
   })


### PR DESCRIPTION
# Pull Request

## Description

Add "only Admin" label to all only admin routes with swagger. Removed all previous manual "admin" labels

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Security fix

## Type of Changes

- [ ] Database changes
- [ ] Schema changes (migration included)
- [ ] Seed data changes
- [ ] API changes
- [ ] New Entity
- [ ] Translation updates (`src/i18n/**`)

## Changes Made

- Change 1
- Change 2
- Change 3

## Testing

- [ ] White box testing
- [ ] Black box testing
- [ ] Translation checks (`npm run i18n:validate` and `npm run i18n:missing`)

- Test coverage: X%

## Deployment Notes

- [ ] No special deployment steps required
- [ ] Environment variables added/changed
- [ ] Configuration changes required
- [ ] Database migration required
- [ ] Cache invalidation required

Special deployment instructions:

```bash
# Add any special deployment commands here
```

## Screenshots (if applicable)

Add screenshots to help explain your changes.

## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
- [ ] Translation files preserve key parity and placeholders with `en`

## Additional Notes

Add any additional notes for reviewers here. Like Related Issues, Perfomance Impact, Breaking Chances.


---

## 🐳 Docker Image Preview

**Available tags:**
- `ghcr.io/reedu-reengineering-education/foodmission-data-framework:pr-292`
- `ghcr.io/reedu-reengineering-education/foodmission-data-framework:sha-2b94987`

**Pull and test:**
```bash
docker pull ghcr.io/reedu-reengineering-education/foodmission-data-framework:pr-292
docker run -p 3000:3000 ghcr.io/reedu-reengineering-education/foodmission-data-framework:pr-292
```

**Multi-arch support:** ✅ AMD64 & ARM64
